### PR TITLE
fix: correct neural-mass bugs, dedup recurrent conns, NumPy docstrings + tests

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -86,3 +86,51 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
   behind** local `main` — `docs/roadmap.md` (added in unpushed commit `3ca0bfa`) was absent
   from the worktree. Read it via `git show main:docs/roadmap.md`. If a future goal needs the
   roadmap and it's missing, check whether the roadmap commit has reached `origin/main` yet.
+
+### 2026-06-18 · goal-01 code-correctness
+- **Bugs fixed (TDD red→green):**
+  - `coupling.py` `LaplacianConnParam`: method/attr name collision — renamed the
+    method `normalize`→`_laplacian`, passed as `precompute=self._laplacian`; the
+    `normalize` mode string attribute now stands alone. (precompute is *lazy* — only
+    called in `Param.value()`/`cache()` — so attr ordering after `super().__init__` is fine.)
+  - `jansen_rit.py` `JansenRitTR.update`: `inp_*_tr` were referenced inside the sub-step
+    closure before assignment; moved the `conn.update_tr()` + `k*input` lines above `def step`.
+  - `noise.py` `BrownianNoise.update`: increment now `sigma*sqrt(dt)*noise` (variance scales
+    with dt). Unit-safe form: `sigma * u.math.sqrt(dt/u.ms) * noise` (raw `nA + nA*sqrt(ms)` raises).
+  - `noise.py` colored noise: `BlueNoise` beta -1→-2 (PSD∝f²), `VioletNoise` -2→-4 (PSD∝f⁴).
+  - `forward_model.py` `LeadFieldModel`: fixed docstring/shape drift and the dangling
+    `self._noise_cov_q` ref in `_sample_noise` (it's the Cholesky factor `_noise_conv_Lc`).
+  - `jansen_rit.py` `s_max`: docstring said 2.5 Hz, code default 5.0 Hz. Literature value is
+    `2·e0 = 5 s⁻¹` (Jansen & Rit 1995) → code was right, fixed the **docstring** only.
+- **Low-risk debt:** deduped `AdditiveConn`/`DelayedAdditiveConn` into `coupling.py` (single
+  source; both read state via `u.get_magnitude` → no-op on unitless HORN `'y'`, strips units
+  from Jansen `'M'`; HORN/Jansen call sites pass `state=`). Replaced `brainmass.delay_index`
+  self-import in `jansen_rit.py` with the local `delay_index`. Converted Google→NumPy docstrings
+  in `utils.py`, `leadfield.py`, `wong_wang.py`.
+- **Leadfield overlap decision:** keep BOTH. `LeadFieldModel` (forward_model.py) = unit-aware
+  physical forward operator (units, vertex→region aggregation, noise cov). `LeadfieldReadout`
+  (leadfield.py) = lightweight *trainable* EEG head on unitless arrays. Added reciprocal
+  "use X when" + `See Also` notes to each.
+- **New latent findings (NOT fixed — out of scope; flagged for maintainer):**
+  - `LeadfieldReadout.normalize_leadfield` is labelled "L2" but computes `sum(sqrt(w²))=sum(|w|)`
+    = **L1** norm. Left numerics unchanged; corrected the docstring/comment to say L1 and tested L1.
+    Decide whether L2 (`sqrt(sum(w²))`) was intended.
+  - `JansenRitNetwork` multi-layer is broken: a layer emits an mV `Quantity`, the next layer
+    re-multiplies its input by `u.mV` → `UnitMismatchError`. Single-layer works. Marked the
+    multi-layer test `xfail(strict)`; construction is still exercised.
+- **Infra:** root `conftest.py` forces matplotlib `Agg` + autouse `plt.close("all")` so the
+  `test_demo_*` (`plot=True`, `plt.show()`) no longer block pytest. Added test files:
+  `horn_test.py`, `leadfield_test.py`, `utils_test.py` (HORN had none before).
+- **Coverage:** all 8 changed source files ≥95% (forward_model/jansen_rit/leadfield/utils/
+  wong_wang = 100%); suite 229 passed, 1 xfailed.
+- **Gotchas for next goal:**
+  - **`/mnt/d` (drvfs) + coverage's C/sysmon/pytrace tracer aborts (SIGABRT) on the `saiunit`
+    C-extension import.** Workaround: a driver that imports `jax/brainunit/brainstate/braintools`
+    FIRST (loads the C-ext uninstrumented), THEN `cov.start()` + `pytest.main([...])`. See the
+    pattern used this goal.
+  - **File-tool absolute paths go where you point them.** The session CWD is the worktree, but
+    an absolute path to `/mnt/d/.../brainmass/brainmass/utils.py` writes to **main**, not the
+    worktree (`.../.claude/worktrees/<wt>/brainmass/...`). Use the worktree path or relative-
+    from-CWD. (Recovered with `git -C <main> checkout HEAD -- <file>`.)
+  - Bumpy `Edit`-tool persistence was observed on drvfs earlier; `Write` (whole-file) and
+    Bash read-modify-write (`.count()==1` guard) are reliable.

--- a/brainmass/coupling.py
+++ b/brainmass/coupling.py
@@ -16,11 +16,13 @@
 
 from typing import Union, Tuple, Callable, Literal, Optional
 
+import braintools
 import brainstate
 import brainunit as u
+import numpy as np
 from brainstate.nn import Param, Module, init_maybe_prefetch, Transform, IdentityT, Regularization
 
-from .typing import Parameter
+from .typing import Parameter, Initializer
 from .utils import set_module_as
 
 # Typing alias for static type hints
@@ -482,7 +484,11 @@ class LaplacianConnParam(Param):
         eps: float = 1e-12,
         return_diag: bool = False,
     ):
-        super().__init__(W, fit=fit, precompute=self.normalize, t=t, reg=reg)
+        # ``normalize`` is the normalization *mode* string ("rw"/"sym"/None); the
+        # precompute callback is the (renamed) ``_laplacian`` method, so the two
+        # no longer collide on the ``normalize`` name. precompute is invoked
+        # lazily by Param.value()/cache(), after these attributes are set.
+        super().__init__(W, fit=fit, precompute=self._laplacian, t=t, reg=reg)
         self.mask = mask
         self.original_W = W
         self.normalize = normalize
@@ -494,7 +500,7 @@ class LaplacianConnParam(Param):
                     f'Mask shape {mask.shape} must match W shape {W.shape}.'
                 )
 
-    def normalize(self, weight):
+    def _laplacian(self, weight):
         weight = u.math.exp(u.get_magnitude(weight)) * self.original_W
         if self.mask is not None:
             weight = weight * self.mask
@@ -504,3 +510,98 @@ class LaplacianConnParam(Param):
             eps=self.eps,
             return_diag=self.return_diag,
         )
+
+
+class AdditiveConn(Module):
+    r"""Additive recurrent connection: a dense linear map of a model state.
+
+    Reads a named hidden state of ``model`` and applies a trainable linear
+    projection. Shared by the HORN layers (``state='y'``) and the Jansen-Rit
+    layers (``state='M'``); ``brainunit.get_magnitude`` is a no-op on the unitless
+    HORN state and strips units from the unit-carrying Jansen-Rit state.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The dynamics module whose state is read.
+    state : str, default 'y'
+        Name of the model attribute (a ``State``) to read; e.g. ``'y'`` (HORN
+        velocity) or ``'M'`` (Jansen-Rit pyramidal potential).
+    w_init : Callable, default KaimingNormal
+        Initializer for the linear weight matrix.
+    b_init : Callable, default ZeroInit
+        Initializer for the linear bias.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        model: Module,
+        state: str = 'y',
+        w_init: Callable = braintools.init.KaimingNormal(),
+        b_init: Callable = braintools.init.ZeroInit(),
+    ):
+        super().__init__()
+
+        self.model = model
+        self.state = state
+        self.linear = brainstate.nn.Linear(
+            self.model.in_size, self.model.out_size, w_init=w_init, b_init=b_init
+        )
+
+    def update_tr(self, *args, **kwargs):
+        return 0.
+
+    def update(self, *args, **kwargs):
+        x = u.get_magnitude(getattr(self.model, self.state).value)
+        return self.linear(x)
+
+
+class DelayedAdditiveConn(Module):
+    r"""Delayed additive recurrent connection.
+
+    Prefetches a delayed model state and applies :func:`additive_coupling`.
+    Shared by the HORN layers (``state='y'``) and the Jansen-Rit layers
+    (``state='M'``).
+
+    Parameters
+    ----------
+    model : brainstate.nn.Dynamics
+        The dynamics module whose delayed state is read.
+    delay_time : Initializer or ArrayLike
+        Per-connection delay times, shaped ``(n_hidden, n_hidden)``.
+    state : str, default 'y'
+        Name of the model state to prefetch with delay.
+    delay_init : Initializer, default ZeroInit
+        Initializer for the delay buffer.
+    w_init : Callable, default KaimingNormal
+        Initializer for the coupling weight matrix.
+    k : Parameter, default 1.0
+        Global coupling strength.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        model: Module,
+        delay_time: Initializer,
+        state: str = 'y',
+        delay_init: Initializer = braintools.init.ZeroInit(),
+        w_init: Callable = braintools.init.KaimingNormal(),
+        k: Parameter = 1.0,
+    ):
+        super().__init__()
+
+        n_hidden = model.varshape[0]
+        delay_time = braintools.init.param(delay_time, (n_hidden, n_hidden))
+        neuron_idx = np.tile(np.expand_dims(np.arange(n_hidden), axis=0), (n_hidden, 1))
+        self.prefetch = model.prefetch_delay(state, delay_time, neuron_idx, init=delay_init)
+        self.weights = Param(braintools.init.param(w_init, (n_hidden, n_hidden)))
+        self.k = Param.init(k)
+
+    def update_tr(self, *args, **kwargs):
+        return 0.
+
+    def update(self, *args, **kwargs):
+        delayed = u.get_magnitude(self.prefetch())
+        return additive_coupling(delayed, self.weights.value(), self.k.value())

--- a/brainmass/coupling_test.py
+++ b/brainmass/coupling_test.py
@@ -16,6 +16,7 @@
 import brainstate
 import brainunit as u
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import brainmass
@@ -212,3 +213,89 @@ class TestAdditiveCoupling:
         coup.init_state()
         with pytest.raises(ValueError):
             _ = coup.update()
+
+
+class TestLaplacianConnParam:
+    """LaplacianConnParam: precompute method must not collide with the mode attr."""
+
+    @staticmethod
+    def _W():
+        return jnp.array([[0., 1., 1.],
+                          [1., 0., 1.],
+                          [1., 1., 0.]])
+
+    def test_normalization_method_renamed_no_collision(self):
+        # The precompute callback was renamed to ``_laplacian``; ``normalize`` is
+        # the mode string. On the buggy version ``_laplacian`` does not exist.
+        p = brainmass.LaplacianConnParam(self._W(), normalize='sym')
+        assert callable(getattr(p, '_laplacian', None))
+        assert p.normalize == 'sym'
+
+    @pytest.mark.parametrize('mode', [None, 'rw', 'sym'])
+    def test_value_matches_reference(self, mode):
+        W = self._W()
+        p = brainmass.LaplacianConnParam(W, normalize=mode)
+        got = p.value()
+        exp = brainmass.laplacian_connectivity(u.math.exp(W) * W, normalize=mode)
+        assert u.math.allclose(got, exp)
+
+    def test_value_with_mask(self):
+        W = self._W()
+        mask = jnp.array([[0., 1., 0.],
+                          [1., 0., 1.],
+                          [0., 1., 0.]])
+        p = brainmass.LaplacianConnParam(W, normalize='sym', mask=mask)
+        got = p.value()
+        exp = brainmass.laplacian_connectivity(u.math.exp(W) * W * mask, normalize='sym')
+        assert u.math.allclose(got, exp)
+
+    def test_return_diag_returns_tuple(self):
+        W = self._W()
+        p = brainmass.LaplacianConnParam(W, normalize='rw', return_diag=True)
+        L, d = p.value()
+        expL, expd = brainmass.laplacian_connectivity(
+            u.math.exp(W) * W, normalize='rw', return_diag=True)
+        assert u.math.allclose(L, expL)
+        assert u.math.allclose(d, expd)
+
+    def test_mask_shape_mismatch_raises(self):
+        W = self._W()
+        with pytest.raises(ValueError):
+            brainmass.LaplacianConnParam(W, mask=jnp.ones((2, 2)))
+
+
+class TestSharedRecurrentConn:
+    """Direct tests for the deduplicated AdditiveConn / DelayedAdditiveConn.
+
+    These classes were unified into coupling.py from horn.py + jansen_rit.py.
+    They read a named state via ``u.get_magnitude`` so they work both on a
+    unitless state (HORN 'y') and a unit-carrying state (Jansen 'M').
+    """
+
+    def test_additive_conn_reads_named_state_and_update_tr_zero(self):
+        import brainstate
+        from brainmass.coupling import AdditiveConn
+        brainstate.environ.set(dt=0.1 * u.ms)
+        model = brainmass.HORNStep(4)
+        brainstate.nn.init_all_states(model)
+        conn = AdditiveConn(model, state='y')
+        brainstate.nn.init_all_states(conn)
+        out = conn.update()
+        assert out.shape == (4,)
+        assert np.all(np.isfinite(np.asarray(out)))
+        # update_tr is a no-op contributing zero for the non-delayed conn.
+        assert float(np.asarray(conn.update_tr())) == 0.0
+
+    def test_delayed_additive_conn_update_tr_zero(self):
+        import brainstate
+        from brainmass.coupling import DelayedAdditiveConn
+        brainstate.environ.set(dt=0.1 * u.ms)
+        model = brainmass.HORNStep(4)
+        brainstate.nn.init_all_states(model)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(4, 4)).astype('float32')) * u.ms
+        conn = DelayedAdditiveConn(model, delay_time=delay, state='y')
+        brainstate.nn.init_all_states(conn)
+        assert float(np.asarray(conn.update_tr())) == 0.0
+        out = conn.update()
+        assert out.shape == (4,)
+        assert np.all(np.isfinite(np.asarray(out)))

--- a/brainmass/forward_model.py
+++ b/brainmass/forward_model.py
@@ -264,6 +264,20 @@ class LeadFieldModel(nn.Module):
         unit **sensor_unit^2**, or a unitless array in which case its unit is assumed compatible
         with ``sensor_unit**2``. Noise is sampled i.i.d. across time (same covariance at each step).
 
+    See Also
+    --------
+    brainmass.leadfield.LeadfieldReadout
+        A lightweight, trainable EEG readout head.
+
+    Notes
+    -----
+    Use :class:`LeadFieldModel` when you need a physically faithful forward
+    operator: explicit physical units, optional vertex-to-region aggregation,
+    and additive measurement noise with a configurable covariance. Prefer
+    :class:`brainmass.leadfield.LeadfieldReadout` instead when you only need a
+    lightweight, *trainable* EEG readout head that operates on plain (unitless)
+    arrays with optional row normalisation / demeaning.
+
     """
     __module__ = 'brainmass'
 
@@ -297,8 +311,21 @@ class LeadFieldModel(nn.Module):
 
     def _sample_noise(self, T: int) -> Quantity:
         """
-        Sample Gaussian sensor noise E (M,T) with covariance self._noise_cov_q per time step.
-        Returns a Quantity in sensor_unit.
+        Sample i.i.d. Gaussian sensor noise of shape ``(T, M)``.
+
+        Each row is drawn from a zero-mean Gaussian with covariance ``noise_cov``
+        using its Cholesky factor ``self._noise_conv_Lc`` (built in ``__init__``
+        when ``noise_cov`` is provided).
+
+        Parameters
+        ----------
+        T : int
+            Number of time steps (rows) to sample.
+
+        Returns
+        -------
+        Quantity
+            Sensor noise of shape ``(T, M)`` with unit ``sensor_unit``.
         """
         z = brainstate.random.randn(T, self.M)
         e = z @ self._noise_conv_Lc  # (T,M) @ (M,M) -> (T,M)
@@ -319,27 +346,31 @@ class LeadFieldModel(nn.Module):
 
         Parameters
         ----------
-        nmm_obs_or_dipoles : ArrayLike
-            ``(R, T)`` region time series. If `already_in_dipole_unit=False`, this is the
-            **NMM observable** (e.g., membrane potential in mV) which will be mapped to dipole
-            moment via `scale`. If `already_in_dipole_unit=True`, it is interpreted directly as
-            dipole moment (ECD) in `dipole_unit`.
-            Accepts unitless arrays (units are attached via `scale`/constructor) or `Quantity`.
+        nmm_obs_or_dipoles : ArrayLike or Quantity
+            Region time series with shape ``(..., R)`` (e.g. ``(T, R)``). It is the
+            **NMM observable** (e.g. membrane potential in mV) and is mapped to the
+            dipole moment via ``scale`` (``s = scale * nmm_obs_or_dipoles``). When
+            ``scale`` is dimensionless the input is treated as already being in
+            ``dipole_unit``. Accepts unitless arrays (units attached via
+            ``scale``/constructor) or a `Quantity`.
 
         Returns
         -------
-        y :
-            Sensor-space time series **Quantity** of shape ``(M, T)`` with unit `sensor_unit`.
+        y : Quantity
+            Sensor-space time series of shape ``(..., M)`` (e.g. ``(T, M)``) with
+            unit ``sensor_unit``.
 
         Notes
         -----
-        The mapping uses the instantaneous linear model:
+        The mapping uses the instantaneous linear model
 
         .. math::
-            \mathbf{Y} = \mathbf{S}\,\mathbf{L} + \mathbf{E}.
+            \mathbf{Y} = \mathbf{S}\,\mathbf{L} + \mathbf{E},
 
-        where :math:`\mathbf{S}` stacks dipoles over time and :math:`\mathbf{E}` is sampled per
-        time step from :math:`\mathcal{N}(\mathbf{0}, \boldsymbol{\Sigma})` if enabled.
+        where :math:`\mathbf{S}` (shape ``(..., R)``) stacks dipoles over time,
+        :math:`\mathbf{L}` has shape ``(R, M)``, and :math:`\mathbf{E}` is sampled
+        per time step from :math:`\mathcal{N}(\mathbf{0}, \boldsymbol{\Sigma})`
+        when ``noise_cov`` is provided.
 
         """
         # 1) Ensure dipoles S (T, R) as Quantity in dipole_unit

--- a/brainmass/forward_model_test.py
+++ b/brainmass/forward_model_test.py
@@ -10,9 +10,11 @@ Covers:
 
 import brainunit as u
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import brainmass
+import brainstate
 
 
 class TestLeadFieldModel:
@@ -174,3 +176,76 @@ class TestBOLDSignal:
         dx, df, dv, dq = bold.derivative((x, f, v, q), 0.0, z)
         for arr in (dx, df, dv, dq):
             assert arr.shape == (R,)
+
+
+class TestLeadFieldModelNoise:
+    """Exercise the optional sensor-noise (noise_cov) path / _sample_noise."""
+
+    def test_noise_cov_forward_shape_and_unit(self):
+        R, M, T = 2, 3, 4
+        L = jnp.ones((R, M), dtype=jnp.float32) * (u.mV / (u.nA * u.meter))
+        nmm = jnp.ones((T, R), dtype=jnp.float32) * (1.0 * u.mV)
+        cov = jnp.eye(M, dtype=jnp.float32) * (0.5 * u.mV ** 2)
+        brainstate.random.seed(0)
+        model = brainmass.LeadFieldModel(
+            in_size=(R,), out_size=(M,), L=L, sensor_unit=u.mV, noise_cov=cov)
+        y = model.update(nmm)
+        assert y.shape == (T, M)
+        assert u.get_unit(y).has_same_dim(u.mV)
+
+    def test_sample_noise_shape_unit_and_determinism(self):
+        R, M = 2, 5
+        L = jnp.ones((R, M), dtype=jnp.float32) * (u.mV / (u.nA * u.meter))
+        cov = jnp.eye(M, dtype=jnp.float32) * (1.0 * u.mV ** 2)
+        model = brainmass.LeadFieldModel(
+            in_size=(R,), out_size=(M,), L=L, sensor_unit=u.mV, noise_cov=cov)
+        brainstate.random.seed(1)
+        e1 = model._sample_noise(7)
+        brainstate.random.seed(1)
+        e2 = model._sample_noise(7)
+        assert e1.shape == (7, M)  # (T, M), not (M, T)
+        assert u.get_unit(e1).has_same_dim(u.mV)
+        assert u.math.allclose(e1, e2)
+
+
+class TestBOLDSignalLifecycle:
+    """Exercise BOLDSignal.init_state / update / bold (the hemodynamic readout)."""
+
+    def test_update_and_bold(self):
+        R = 4
+        brainstate.environ.set(dt=0.01)  # BOLDSignal is dimensionless; dt must be unitless
+        bold = brainmass.BOLDSignal(in_size=(R,))
+        brainstate.nn.init_all_states(bold)
+        # Drive with a small neural input for several steps.
+        z = 0.1 * jnp.ones((R,), dtype=jnp.float32)
+        for _ in range(5):
+            bold.update(z)
+        out = bold.bold()
+        assert out.shape == (R,)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+
+class TestLeadFieldModelExtras:
+    def test_R_and_M_properties(self):
+        R, M = 2, 3
+        L = jnp.ones((R, M), dtype=jnp.float32) * (u.mV / (u.nA * u.meter))
+        model = brainmass.LeadFieldModel(in_size=(R,), out_size=(M,), L=L, sensor_unit=u.mV)
+        assert model.R == R
+        assert model.M == M
+
+    def test_compress_vertex_leadfield_unitless(self):
+        # Unitless inputs exercise the non-Quantity return branch.
+        M, V, R = 3, 2, 4
+        L_vertex = jnp.arange(M * 3 * V, dtype=jnp.float32).reshape(M, 3 * V)
+        W = jnp.ones((3 * V, R), dtype=jnp.float32)
+        L_region = brainmass.LeadFieldModel.compress_vertex_leadfield(L_vertex, W)
+        assert L_region.shape == (M, R)
+        assert not isinstance(L_region, u.Quantity)
+
+    def test_build_fixed_orientation_weights_default_area(self):
+        # Omitting area_weights_V exercises the area=None default branch.
+        V, R = 3, 2
+        normals = jnp.eye(3, dtype=jnp.float32)
+        parcel = jnp.ones((V, R), dtype=jnp.float32)
+        W = brainmass.LeadFieldModel.build_fixed_orientation_weights(normals, parcel)
+        assert W.shape == (3 * V, R)

--- a/brainmass/horn.py
+++ b/brainmass/horn.py
@@ -23,7 +23,9 @@ import jax.numpy as jnp
 import numpy as np
 from brainstate.nn import Param, Module, Dynamics
 
-from .coupling import AdditiveCoupling, additive_coupling, LaplacianConnParam
+from .coupling import (
+    AdditiveCoupling, additive_coupling, LaplacianConnParam, AdditiveConn, DelayedAdditiveConn
+)
 from .typing import Initializer, Parameter
 
 __all__ = [
@@ -231,51 +233,6 @@ class HORNStep(Dynamics):
         self.x.value = x_t
         self.y.value = y_t
         return x_t
-
-
-class AdditiveConn(Module):
-    def __init__(
-        self,
-        model: Module,
-        w_init: Callable = braintools.init.KaimingNormal(),
-        b_init: Callable = braintools.init.ZeroInit(),
-    ):
-        super().__init__()
-
-        self.model = model
-        self.linear = brainstate.nn.Linear(self.model.in_size, self.model.out_size, w_init=w_init, b_init=b_init)
-
-    def update_tr(self, *args, **kwargs):
-        return 0.
-
-    def update(self, *args, **kwargs):
-        return self.linear(self.model.y.value)
-
-
-class DelayedAdditiveConn(Module):
-    def __init__(
-        self,
-        model: Dynamics,
-        delay_time: Initializer,
-        delay_init: Initializer = braintools.init.ZeroInit(),
-        w_init: Callable = braintools.init.KaimingNormal(),
-        k: Parameter = 1.0,
-    ):
-        super().__init__()
-
-        n_hidden = model.varshape[0]
-        delay_time = braintools.init.param(delay_time, (n_hidden, n_hidden))
-        neuron_idx = np.tile(np.expand_dims(np.arange(n_hidden), axis=0), (n_hidden, 1))
-        self.prefetch = model.prefetch_delay('y', delay_time, neuron_idx, init=delay_init)
-        self.weights = Param(braintools.init.param(w_init, (n_hidden, n_hidden)))
-        self.k = Param.init(k)
-
-    def update_tr(self, *args, **kwargs):
-        return 0.
-
-    def update(self, *args, **kwargs):
-        delayed = self.prefetch()
-        return additive_coupling(delayed, self.weights.value(), self.k.value())
 
 
 class DelayedAdditiveConnTR(Module):

--- a/brainmass/horn_test.py
+++ b/brainmass/horn_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainstate
+import brainunit as u
+
+import brainmass
+from brainmass.horn import HORN_TR
+
+
+def _seq(T, n, seed=0):
+    brainstate.random.seed(seed)
+    return jnp.asarray(np.random.randn(T, n).astype('float32'))
+
+
+class TestHORNStep:
+    def test_init_and_update_shape(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        m = brainmass.HORNStep(4)
+        brainstate.nn.init_all_states(m)
+        assert m.x.value.shape == (4,)
+        out = m.update(jnp.ones(4))
+        assert out.shape == (4,)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+
+class TestHORNSeqLayer:
+    def test_additive_path(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        m = brainmass.HORNSeqLayer(3, 5)
+        brainstate.nn.init_all_states(m)
+        out = m.update(_seq(10, 3))
+        assert out.shape == (10, 5)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+    def test_delayed_path(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype('float32')) * u.ms
+        m = brainmass.HORNSeqLayer(3, 5, delay=delay)
+        brainstate.nn.init_all_states(m)
+        out = m.update(_seq(10, 3))
+        assert out.shape == (10, 5)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+    def test_record_state(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        m = brainmass.HORNSeqLayer(3, 5)
+        brainstate.nn.init_all_states(m)
+        out = m.update(_seq(8, 3), record_state=True)
+        st, ys = out
+        assert set(st.keys()) == {'x', 'y'}
+
+
+class TestHORNSeqNetwork:
+    def test_single_layer(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        net = brainmass.HORNSeqNetwork(4, 6, 2)
+        brainstate.nn.init_all_states(net)
+        out = net.update(_seq(12, 4))
+        assert out.shape == (2,)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+    def test_multi_layer_and_hidden_activation(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        net = brainmass.HORNSeqNetwork(4, [6, 8], 3)
+        brainstate.nn.init_all_states(net)
+        x = _seq(12, 4)
+        out = net.update(x)
+        assert out.shape == (3,)
+        acts = net.hidden_activation(x)
+        assert len(acts) == 2
+
+
+class TestHORN_TR:
+    @pytest.mark.parametrize('rec_type,with_delay', [
+        (None, False),
+        ('additive', True),
+        ('additive_tr', True),
+        ('laplacian', True),
+        ('laplacian_tr', True),
+    ])
+    def test_rec_types(self, rec_type, with_delay):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        n = 5
+        delay = (jnp.asarray(np.random.randint(1, 4, size=(n, n)).astype('float32')) * u.ms
+                 if with_delay else None)
+        kwargs = dict(tr=0.5 * u.ms)
+        if rec_type is not None:
+            kwargs.update(delay=delay, rec_type=rec_type)
+        m = HORN_TR(n, **kwargs)
+        brainstate.nn.init_all_states(m)
+        out = m.update(_seq(6, n))
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+    def test_unknown_rec_type_raises(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype('float32')) * u.ms
+        with pytest.raises(ValueError):
+            HORN_TR(5, delay=delay, rec_type='nope')

--- a/brainmass/jansen_rit.py
+++ b/brainmass/jansen_rit.py
@@ -25,8 +25,7 @@ from brainstate.nn import (
     exp_euler_step, Param, Dynamics, Module, init_maybe_prefetch, Delay,
 )
 
-import brainmass
-from .coupling import additive_coupling
+from .coupling import additive_coupling, AdditiveConn, DelayedAdditiveConn
 from .noise import Noise, GaussianNoise
 from .typing import Parameter, Initializer
 from .utils import delay_index
@@ -138,7 +137,7 @@ class JansenRitStep(brainstate.nn.Dynamics):
          - 0.125-0.375
        * - smax
          - Max firing rate
-         - 2.5 s^-1
+         - 5.0 s^-1
          - -
        * - v0
          - Firing threshold
@@ -165,8 +164,9 @@ class JansenRitStep(brainstate.nn.Dynamics):
         Global connectivity scaling (dimensionless).
     a1, a2, a3, a4 : `ArrayLike` or `Callable`, defaults `1., 0.8, 0.25, 0.25`
         Connectivity parameters (dimensionless) used as in the equations above.
-    s_max : `ArrayLike` or `Callable`, default `2.5 * u.Hz`
-        Maximum firing rate for the sigmoid, units s^-1.
+    s_max : `ArrayLike` or `Callable`, default `5.0 * u.Hz`
+        Maximum firing rate for the sigmoid, units s^-1. This is the
+        literature value :math:`2 e_0 = 5` s\ :sup:`-1` (Jansen & Rit, 1995).
     v0 : `ArrayLike` or `Callable`, default `6. * u.mV`
         Sigmoid midpoint (mV).
     r : `ArrayLike` or `Callable`, default `0.56`
@@ -627,7 +627,7 @@ class JansenRitTR(Dynamics):
         n_hidden = self.varshape[0]
         dt = brainstate.environ.get_dt()
         self.delay = Delay(self.step.M_init(self.varshape), init=delay_init)
-        self.delay_access = self.delay.access('delay', delay * dt, brainmass.delay_index(n_hidden))
+        self.delay_access = self.delay.access('delay', delay * dt, delay_index(n_hidden))
 
         # connectivity
         self.conn = LaplacianConnectivity(
@@ -651,6 +651,16 @@ class JansenRitTR(Dynamics):
         record_state: bool = False,
         iter_input: bool = False
     ):
+        n_step = int(self.tr / brainstate.environ.get_dt())
+        if iter_input:
+            assert input.shape[0] == n_step, f'Input length {input.shape[0]} does not match number of steps {n_step}'
+
+        # Per-TR terms (constant across the sub-step loop) are computed *before*
+        # the closure so they are bound when ``step`` runs, rather than relying on
+        # Python late-binding of names assigned after the closure was defined.
+        input = self.k.value() * input
+        inp_M_tr, inp_E_tr, inp_I_tr = self.conn.update_tr()
+
         def step(inp):
             ext = inp if iter_input else input
             inp_M_step, inp_E_step, inp_I_step = self.conn.update()
@@ -659,12 +669,6 @@ class JansenRitTR(Dynamics):
             inp_I = (inp_I_tr + inp_I_step) * u.mV
             self.step.update(inp_M, inp_E, inp_I)
 
-        n_step = int(self.tr / brainstate.environ.get_dt())
-        if iter_input:
-            assert input.shape[0] == n_step, f'Input length {input.shape[0]} does not match number of steps {n_step}'
-
-        input = self.k.value() * input
-        inp_M_tr, inp_E_tr, inp_I_tr = self.conn.update_tr()
         brainstate.transform.for_loop(step, input if iter_input else np.arange(n_step))
         self.delay.update(self.step.M.value)
         activity = self.step.E.value - self.step.I.value
@@ -674,46 +678,6 @@ class JansenRitTR(Dynamics):
             state = dict(M=self.step.M.value, E=self.step.E.value, I=self.step.I.value)
             return activity, state
         return activity
-
-
-class AdditiveConn(Module):
-    def __init__(
-        self,
-        model: Module,
-        w_init: Callable = braintools.init.KaimingNormal(),
-        b_init: Callable = braintools.init.ZeroInit(),
-    ):
-        super().__init__()
-
-        self.model = model
-        self.linear = brainstate.nn.Linear(self.model.in_size, self.model.out_size, w_init=w_init, b_init=b_init)
-
-    def update(self, *args, **kwargs):
-        inp = u.get_magnitude(self.model.M.value)
-        return self.linear(inp)
-
-
-class DelayedAdditiveConn(Module):
-    def __init__(
-        self,
-        model: Dynamics,
-        delay_time: Initializer,
-        delay_init: Initializer = braintools.init.ZeroInit(),
-        w_init: Callable = braintools.init.KaimingNormal(),
-        k: Parameter = 1.0,
-    ):
-        super().__init__()
-
-        n_hidden = model.varshape[0]
-        delay_time = braintools.init.param(delay_time, (n_hidden, n_hidden))
-        neuron_idx = np.tile(np.expand_dims(np.arange(n_hidden), axis=0), (n_hidden, 1))
-        self.prefetch = model.prefetch_delay('M', delay_time, neuron_idx, init=delay_init)
-        self.weights = Param(braintools.init.param(w_init, (n_hidden, n_hidden)))
-        self.k = Param.init(k)
-
-    def update(self, *args, **kwargs):
-        delayed = u.get_magnitude(self.prefetch())
-        return additive_coupling(delayed, self.weights.value(), self.k.value())
 
 
 class JansenRitLayer(Module):
@@ -784,9 +748,9 @@ class JansenRitLayer(Module):
         )
         self.i2h = brainstate.nn.Linear(n_input, n_hidden, w_init=inp_w_init, b_init=inp_b_init)
         if delay is None:
-            self.h2h = AdditiveConn(self.dynamics, w_init=rec_w_init, b_init=rec_b_init)
+            self.h2h = AdditiveConn(self.dynamics, state='M', w_init=rec_w_init, b_init=rec_b_init)
         else:
-            self.h2h = DelayedAdditiveConn(self.dynamics, delay, delay_init=delay_init, w_init=rec_w_init)
+            self.h2h = DelayedAdditiveConn(self.dynamics, delay, state='M', delay_init=delay_init, w_init=rec_w_init)
 
     def update(self, inputs, record_state: bool = False):
         def step(inp):

--- a/brainmass/jansen_rit_test.py
+++ b/brainmass/jansen_rit_test.py
@@ -19,6 +19,7 @@ import brainunit as u
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 import brainmass
 
@@ -468,3 +469,163 @@ class TestJansenRitModel:
             plt.close()
 
         return time, outputs
+
+
+class TestJansenRitTR:
+    """JansenRitTR.update: per-TR terms must be ready before the sub-step loop."""
+
+    @staticmethod
+    def _make(n=3, tr=1e-3 * u.second, dt=1e-4 * u.second, seed=0):
+        brainstate.environ.set(dt=dt)
+        brainstate.random.seed(seed)
+        sc = jnp.asarray(np.random.rand(n, n))
+        sc = sc - jnp.diag(jnp.diag(sc))
+        delay = jnp.asarray(np.random.randint(1, 5, size=(n, n)).astype(float))
+        w = jnp.asarray(np.random.randn(n, n) * 0.1)
+        model = brainmass.JansenRitTR(
+            in_size=n, delay=delay, sc=sc, k=1.0,
+            w_ll=w, w_ff=w, w_bb=w, g_l=1.0, g_f=1.0, g_b=1.0, tr=tr,
+        )
+        brainstate.nn.init_all_states(model)
+        return model, n
+
+    def test_update_runs_and_returns_finite(self):
+        model, n = self._make()
+        out = model.update(jnp.zeros(n))
+        out = np.asarray(u.get_magnitude(out))
+        assert out.shape == (n,)
+        assert np.all(np.isfinite(out))
+
+    def test_update_record_state(self):
+        model, n = self._make()
+        out, state = model.update(jnp.zeros(n), record_state=True)
+        assert set(state.keys()) == {'M', 'E', 'I'}
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+    def test_non_integer_n_step(self):
+        # tr/dt = 1e-3 / 0.3e-3 = 3.33 -> int() floors to 3; must still run.
+        model, n = self._make(tr=1e-3 * u.second, dt=0.3e-3 * u.second)
+        out = model.update(jnp.zeros(n))
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+    def test_iter_input_path(self):
+        model, n = self._make(tr=1e-3 * u.second, dt=1e-4 * u.second)
+        n_step = int(1e-3 / 1e-4)  # 10
+        inp = jnp.zeros((n_step, n))
+        out = model.update(inp, iter_input=True)
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+
+class TestJansenRitSmax:
+    def test_default_smax_is_literature_value(self):
+        # Max firing rate s_max = 2 * e0 = 5 s^-1 (Jansen & Rit, 1995).
+        model = brainmass.JansenRitStep(in_size=1)
+        assert model.s_max.value() == 5.0 * u.Hz
+
+
+class TestJansenRitStepRK2:
+    """Cover the non-exp_euler integration branch (uses derivative())."""
+
+    def test_rk2_method_runs(self):
+        brainstate.environ.set(dt=0.0001 * u.second)
+        model = brainmass.JansenRitStep(in_size=3, method='rk2')
+        brainstate.nn.init_all_states(model)
+        out = model.update(E_inp=10. * u.Hz)
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+
+class TestJansenRitTRMask:
+    """Cover the mask branch in LaplacianConnectivity._normalize / _symmetric_normalize."""
+
+    def test_masked_update_runs(self):
+        n = 3
+        brainstate.environ.set(dt=1e-4 * u.second)
+        brainstate.random.seed(0)
+        sc = jnp.asarray(np.random.rand(n, n))
+        sc = sc - jnp.diag(jnp.diag(sc))
+        delay = jnp.asarray(np.random.randint(1, 5, size=(n, n)).astype(float))
+        w = jnp.asarray(np.random.randn(n, n) * 0.1)
+        mask = jnp.asarray((np.random.rand(n, n) > 0.3).astype('float32'))
+        model = brainmass.JansenRitTR(
+            in_size=n, delay=delay, sc=sc, k=1.0,
+            w_ll=w, w_ff=w, w_bb=w, g_l=1.0, g_f=1.0, g_b=1.0,
+            tr=1e-3 * u.second, mask=mask,
+        )
+        brainstate.nn.init_all_states(model)
+        out = model.update(jnp.zeros(n))
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+
+def _jr_seq(T, n, seed=0):
+    brainstate.random.seed(seed)
+    return jnp.asarray(np.random.randn(T, n).astype('float32'))
+
+
+class TestJansenRitLayer:
+    """Cover JansenRitLayer (additive + delayed) — uses the deduped AdditiveConn/DelayedAdditiveConn."""
+
+    def test_additive_path(self):
+        from brainmass.jansen_rit import JansenRitLayer
+        brainstate.environ.set(dt=1e-4 * u.second)
+        m = JansenRitLayer(n_input=3, n_hidden=5)
+        brainstate.nn.init_all_states(m)
+        out = m.update(_jr_seq(6, 3))
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+    def test_delayed_path_and_record_state(self):
+        from brainmass.jansen_rit import JansenRitLayer
+        brainstate.environ.set(dt=1e-4 * u.second)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
+        m = JansenRitLayer(n_input=3, n_hidden=5, delay=delay)
+        brainstate.nn.init_all_states(m)
+        st, out = m.update(_jr_seq(6, 3), record_state=True)
+        assert set(st.keys()) == {'M', 'E', 'I'}
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+
+class TestJansenRit2LayerAndNetwork:
+    """Cover JansenRit2Layer / LaplacianConnV2 / JansenRitNetwork."""
+
+    def test_jansen_rit2_layer_record_state(self):
+        from brainmass.jansen_rit import JansenRit2Layer
+        brainstate.environ.set(dt=1e-4 * u.second)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
+        m = JansenRit2Layer(n_input=3, n_hidden=5, delay=delay)
+        brainstate.nn.init_all_states(m)
+        st, out = m.update(_jr_seq(6, 3), record_state=True)
+        assert set(st.keys()) == {'M', 'E', 'I'}
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+    def test_jansen_rit2_layer_requires_delay(self):
+        from brainmass.jansen_rit import JansenRit2Layer
+        brainstate.environ.set(dt=1e-4 * u.second)
+        with pytest.raises(AssertionError):
+            JansenRit2Layer(n_input=3, n_hidden=5)  # delay is required
+
+    def test_network_single_and_multi_layer(self):
+        from brainmass.jansen_rit import JansenRitNetwork
+        brainstate.environ.set(dt=1e-4 * u.second)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
+        net = JansenRitNetwork(n_input=3, n_hidden=5, n_output=2, delay=delay)
+        brainstate.nn.init_all_states(net)
+        out = net.update(_jr_seq(6, 3))
+        assert out.shape == (2,)  # network emits a single readout from the final state
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))
+
+    @pytest.mark.xfail(
+        reason="Pre-existing latent bug: stacking JansenRit2Layers feeds an mV "
+               "Quantity output into the next layer, which re-multiplies by u.mV "
+               "-> UnitMismatchError. Out of scope for goal-01; documented here. "
+               "Construction (the multi-layer __init__ loop) is still exercised.",
+        raises=Exception,
+        strict=True,
+    )
+    def test_network_multi_layer_unit_chaining_bug(self):
+        from brainmass.jansen_rit import JansenRitNetwork
+        brainstate.environ.set(dt=1e-4 * u.second)
+        delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
+        net = JansenRitNetwork(n_input=3, n_hidden=[5, 5], n_output=2, delay=delay)
+        brainstate.nn.init_all_states(net)
+        out = net.update(_jr_seq(6, 3))
+        assert out.shape == (2,)
+        assert np.all(np.isfinite(np.asarray(u.get_magnitude(out))))

--- a/brainmass/leadfield.py
+++ b/brainmass/leadfield.py
@@ -1,7 +1,21 @@
-"""
-EEG readout modules using leadfield matrix.
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
-Transforms neural mass model source activity to sensor-space EEG signals.
+"""EEG readout modules using a leadfield matrix.
+
+Transforms neural-mass-model source activity to sensor-space EEG signals.
 """
 
 import brainunit as u
@@ -16,21 +30,48 @@ __all__ = [
 
 
 class LeadfieldReadout(Module):
+    r"""Trainable leadfield-matrix EEG readout.
+
+    Transforms a source-activity vector (e.g. ``E - I``) to EEG sensor space
+    using a leadfield matrix:
+
+    .. math::
+
+        \mathrm{EEG} = c_{y0}\, (\hat{L}\, x) - y_0 ,
+
+    where :math:`\hat{L}` is the (optionally row-normalised, demeaned) leadfield
+    matrix and ``x`` is the source-activity vector.
+
+    Parameters
+    ----------
+    lm : Array
+        Leadfield matrix of shape ``(output_size, node_size)``. Wrapped in a
+        trainable :class:`~brainstate.nn.Param`.
+    y0 : Parameter
+        Output bias parameter, subtracted from every channel.
+    cy0 : Parameter
+        Global scaling coefficient applied to the projected activity.
+    normalize : bool, default True
+        If ``True``, scale each leadfield row by its L1 norm (``sum(|w|)``,
+        the sum of absolute values). Note: historically labelled "L2".
+    demean : bool, default True
+        If ``True``, remove the per-channel mean across sensors (columns).
+
+    See Also
+    --------
+    brainmass.forward_model.LeadFieldModel
+        The heavier, unit-aware forward operator.
+
+    Notes
+    -----
+    Use :class:`LeadfieldReadout` when you want a lightweight, *trainable* EEG
+    readout head — the leadfield is a fitted parameter with optional row
+    normalisation / demeaning, and inputs/outputs are plain (unitless) arrays.
+    Use :class:`brainmass.forward_model.LeadFieldModel` instead when you need a
+    physically faithful forward model: explicit physical units, vertex→region
+    aggregation, and additive measurement noise with a configurable covariance.
     """
-    Leadfield matrix EEG readout.
-
-    Transforms source activity (E - I) to EEG sensor space using
-    a leadfield matrix.
-
-    EEG = cy0 * lm_normalized @ (E - I) - y0
-
-    Args:
-        lm: Leadfield matrix parameter (output_size, node_size).
-        y0: Output bias parameter.
-        cy0: Scaling coefficient parameter.
-        normalize: Whether to L2-normalize leadfield rows.
-        demean: Whether to remove mean across channels.
-    """
+    __module__ = 'brainmass'
 
     def __init__(
         self,
@@ -50,18 +91,27 @@ class LeadfieldReadout(Module):
         self.demean = demean
 
     def normalize_leadfield(self, lm: Array) -> Array:
-        """
-        Normalize leadfield matrix.
+        """Row-normalise and/or demean the leadfield matrix.
 
-        Args:
-            lm: (output_size, node_size) leadfield matrix.
+        Applied lazily as the ``precompute`` hook of ``self.lm`` whenever the
+        parameter value is read.
 
-        Returns:
-            Normalized leadfield matrix.
+        Parameters
+        ----------
+        lm : Array
+            Leadfield matrix of shape ``(output_size, node_size)``.
+
+        Returns
+        -------
+        Array
+            The leadfield matrix after optional L1 row normalisation
+            (``normalize``; scales each row by ``sum(|w|)``) and optional
+            per-channel demeaning (``demean``).
         """
 
         if self.normalize:
-            # L2 normalize each row (each sensor's weights)
+            # Scale each row by its L1 norm: sum(|w|). (Comment historically
+            # said "L2"; the code computes sum(sqrt(w**2)) == sum(|w|).)
             row_norms = u.math.sum(u.math.sqrt(lm ** 2), axis=1, keepdims=True)
             lm = lm / row_norms
 
@@ -72,6 +122,19 @@ class LeadfieldReadout(Module):
         return lm
 
     def update(self, x: Array):
+        """Project source activity to EEG sensor space.
+
+        Parameters
+        ----------
+        x : Array
+            Source-activity array whose last axis has length ``node_size``.
+            Leading axes (batch/time) are mapped over automatically.
+
+        Returns
+        -------
+        Array
+            EEG signals with the last axis replaced by ``output_size``.
+        """
         lm = self.lm.value()
         y0 = self.y0.value()
         cy0 = self.cy0.value()

--- a/brainmass/leadfield_test.py
+++ b/brainmass/leadfield_test.py
@@ -1,0 +1,70 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainstate
+from brainstate.nn import Param
+
+import brainmass
+
+
+def _make(normalize=True, demean=True, M=3, N=5, seed=0):
+    brainstate.random.seed(seed)
+    lm = jnp.asarray(np.random.randn(M, N).astype('float32'))
+    readout = brainmass.LeadfieldReadout(
+        lm=lm,
+        y0=Param.init(0.0),
+        cy0=Param.init(1.0),
+        normalize=normalize,
+        demean=demean,
+    )
+    brainstate.nn.init_all_states(readout)
+    return readout, M, N
+
+
+class TestLeadfieldReadout:
+    @pytest.mark.parametrize('normalize,demean', [
+        (True, True), (True, False), (False, True), (False, False),
+    ])
+    def test_update_1d(self, normalize, demean):
+        readout, M, N = _make(normalize, demean)
+        out = readout.update(jnp.ones(N))
+        assert out.shape == (M,)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+    def test_update_batched_vmap(self):
+        readout, M, N = _make()
+        T = 7
+        out = readout.update(jnp.ones((T, N)))
+        assert out.shape == (T, M)
+        assert np.all(np.isfinite(np.asarray(out)))
+
+    def test_row_normalization_makes_unit_l1_rows(self):
+        # normalize_leadfield computes sum(sqrt(w**2)) == sum(|w|), i.e. the L1
+        # norm (despite the historical "L2" label). With demean=False to isolate
+        # normalization, each row's sum of absolute values should be ~1.
+        readout, M, N = _make(normalize=True, demean=False)
+        lm = np.asarray(readout.lm.value())
+        l1_norms = np.abs(lm).sum(axis=1)
+        assert np.allclose(l1_norms, 1.0, atol=1e-5)
+
+    def test_demean_removes_column_mean(self):
+        readout, M, N = _make(normalize=False, demean=True)
+        lm = np.asarray(readout.lm.value())
+        # demean subtracts the per-column (across-channel) mean -> column means ~0
+        assert np.allclose(lm.mean(axis=0), 0.0, atol=1e-5)

--- a/brainmass/noise.py
+++ b/brainmass/noise.py
@@ -103,8 +103,11 @@ class BrownianNoise(Noise):
         mean = self.mean.value()
         sigma = self.sigma.value()
         noise = brainstate.random.randn(*self.varshape)
-        dt_sqrt = u.math.sqrt(brainstate.environ.get_dt())
-        self.x.value = self.x.value + sigma / dt_sqrt * dt_sqrt * noise
+        # Wiener increment dx = sigma * sqrt(dt) * N(0, 1). dt is normalised by a
+        # fixed time unit (ms) so the increment keeps sigma's unit and the
+        # per-step variance scales with dt (same dt/u.ms idiom as HORNStep).
+        dt = brainstate.environ.get_dt()
+        self.x.value = self.x.value + sigma * u.math.sqrt(dt / u.ms) * noise
         return mean + self.x.value
 
 
@@ -177,22 +180,30 @@ class PinkNoise(ColoredNoise):
 
 class BlueNoise(ColoredNoise):
     """
-    Blue (1/f^2) noise.
-    """
-    __module__ = 'brainmass'
+    Blue noise.
 
-    def __init__(self, in_size, mean=None, sigma=1. * u.nA):
-        super().__init__(in_size=in_size, beta=-1.0, mean=mean, sigma=sigma)
-
-
-class VioletNoise(ColoredNoise):
-    """
-    Violet (1/f^3) noise.
+    Power spectral density rises with frequency as ``PSD(f) ∝ f**2`` (i.e.
+    ``beta = -2`` in the ``1/f**beta`` convention, giving the amplitude shaping
+    ``f**(-beta/2) = f``).
     """
     __module__ = 'brainmass'
 
     def __init__(self, in_size, mean=None, sigma=1. * u.nA):
         super().__init__(in_size=in_size, beta=-2.0, mean=mean, sigma=sigma)
+
+
+class VioletNoise(ColoredNoise):
+    """
+    Violet (purple) noise.
+
+    Power spectral density rises with frequency as ``PSD(f) ∝ f**4`` (i.e.
+    ``beta = -4`` in the ``1/f**beta`` convention, giving the amplitude shaping
+    ``f**(-beta/2) = f**2``).
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, in_size, mean=None, sigma=1. * u.nA):
+        super().__init__(in_size=in_size, beta=-4.0, mean=mean, sigma=sigma)
 
 
 class OUProcess(Noise):

--- a/brainmass/noise_test.py
+++ b/brainmass/noise_test.py
@@ -305,3 +305,93 @@ class TestColoredNoise:
             y = n.update()
             assert y.shape == (2, 256)
             assert u.get_unit(y) == u.nA
+
+
+class TestBrownianNoiseScaling:
+    """Brownian (Wiener) increment must scale as ``sigma * sqrt(dt)``."""
+
+    @staticmethod
+    def _first_increment(dt, seed=123, n=50000, sigma=2.0 * u.nA):
+        # First update from a zero initial state equals the per-step increment.
+        brainstate.random.seed(seed)
+        proc = brainmass.BrownianNoise(in_size=n, sigma=sigma)
+        proc.init_state()
+        with brainstate.environ.context(dt=dt):
+            out = proc.update()
+        return np.asarray(u.get_magnitude(out))
+
+    def test_increment_variance_scales_with_dt(self):
+        # Same seed => identical N(0,1) draw, so Var ratio == dt ratio exactly.
+        inc1 = self._first_increment(0.1 * u.ms)
+        inc2 = self._first_increment(0.4 * u.ms)
+        ratio = float(np.var(inc2)) / float(np.var(inc1))
+        # Buggy code (increment == sigma) gives ratio ~ 1; correct gives ~ 4.
+        assert 3.8 < ratio < 4.2, f'variance ratio {ratio} should be ~4 (dt 0.4/0.1)'
+
+    def test_increment_magnitude_matches_sigma_sqrt_dt(self):
+        # At dt == 1 ms the increment std equals sigma (sqrt(dt/ms) == 1).
+        inc = self._first_increment(1.0 * u.ms, sigma=2.0 * u.nA)
+        assert abs(float(np.std(inc)) - 2.0) < 0.1
+
+    def test_zero_sigma_is_deterministic(self):
+        proc = brainmass.BrownianNoise(in_size=10, sigma=0.0 * u.nA)
+        proc.init_state()
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            out = proc.update()
+        assert u.math.allclose(out, 0. * u.nA)
+
+    def test_seed_determinism(self):
+        a = self._first_increment(0.1 * u.ms, seed=7, n=200)
+        b = self._first_increment(0.1 * u.ms, seed=7, n=200)
+        assert np.allclose(a, b)
+
+    def test_update_is_unit_safe_and_finite(self):
+        brainstate.random.seed(0)
+        proc = brainmass.BrownianNoise(in_size=4, sigma=1.5 * u.nA)
+        proc.init_state()
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            out = proc.update()
+        assert u.get_unit(out) == u.nA
+        assert u.math.all(u.math.isfinite(out))
+
+
+class TestColoredNoiseSpectralSlope:
+    """Colored-noise PSD slope: PSD(f) ~ f**(-beta) so log-log slope == -beta."""
+
+    @staticmethod
+    def _psd_slope(noise, seed=0):
+        brainstate.random.seed(seed)
+        y = np.asarray(u.get_magnitude(noise.update()))  # (reps, n)
+        n = y.shape[-1]
+        psd = np.mean(np.abs(np.fft.rfft(y, axis=-1)) ** 2, axis=0)
+        freqs = np.fft.rfftfreq(n)
+        lo, hi = 1, len(freqs)  # exclude DC only
+        f, p = freqs[lo:hi], psd[lo:hi]
+        mask = p > 0
+        return float(np.polyfit(np.log(f[mask]), np.log(p[mask]), 1)[0])
+
+    def _make(self, cls=None, beta=None, in_size=(256, 2048)):
+        n = (cls(in_size=in_size, sigma=1.0 * u.nA) if cls is not None
+             else brainmass.ColoredNoise(in_size=in_size, beta=beta, sigma=1.0 * u.nA))
+        n.init_state()
+        return n
+
+    def test_blue_slope_is_two(self):
+        slope = self._psd_slope(self._make(cls=brainmass.BlueNoise))
+        assert abs(slope - 2.0) < 0.5, f'blue slope {slope} should be ~ +2'
+
+    def test_violet_slope_is_four(self):
+        slope = self._psd_slope(self._make(cls=brainmass.VioletNoise))
+        assert abs(slope - 4.0) < 0.8, f'violet slope {slope} should be ~ +4'
+
+    def test_pink_slope_is_minus_one(self):
+        slope = self._psd_slope(self._make(cls=brainmass.PinkNoise))
+        assert abs(slope + 1.0) < 0.5, f'pink slope {slope} should be ~ -1'
+
+    def test_slope_ordering_vs_white_and_pink(self):
+        s_pink = self._psd_slope(self._make(cls=brainmass.PinkNoise), seed=1)
+        s_white = self._psd_slope(self._make(beta=0.0), seed=2)
+        s_blue = self._psd_slope(self._make(cls=brainmass.BlueNoise), seed=3)
+        s_violet = self._psd_slope(self._make(cls=brainmass.VioletNoise), seed=4)
+        assert s_pink < s_white < s_blue < s_violet
+        assert s_pink < 0 < s_blue

--- a/brainmass/utils.py
+++ b/brainmass/utils.py
@@ -39,26 +39,38 @@ def sys2nd(
     x: Array,
     v: Array
 ) -> Array:
-    """
-    Second-order system dynamics.
+    r"""Compute the acceleration of a second-order linear system.
 
-    Implements the derivative of a second-order linear system:
-        d²x/dt² + 2a·dx/dt + a²·x = A·a·u
+    Implements the canonical second-order kinetic block used by neural-mass
+    models (e.g. Jansen-Rit). The system
 
-    Which can be written as:
-        dv/dt = A·a·u - 2·a·v - a²·x
+    .. math::
 
-    where v = dx/dt
+        \frac{d^2 x}{dt^2} + 2 a \frac{dx}{dt} + a^2 x = A\,a\,u
 
-    Args:
-        A: Amplitude gain parameter.
-        a: Time constant parameter (1/time).
-        u: Input signal.
-        x: Position state (integrated output).
-        v: Velocity state (derivative of position).
+    is written in state-space form with ``v = dx/dt`` as
 
-    Returns:
-        dv/dt - the acceleration (derivative of velocity).
+    .. math::
+
+        \frac{dv}{dt} = A\,a\,u - 2 a v - a^2 x .
+
+    Parameters
+    ----------
+    A : Array
+        Amplitude gain parameter.
+    a : Array
+        Time-constant parameter (units of inverse time).
+    u : Array
+        Input signal.
+    x : Array
+        Position state (the integrated output).
+    v : Array
+        Velocity state (the derivative of ``x``).
+
+    Returns
+    -------
+    Array
+        ``dv/dt`` — the acceleration, i.e. the derivative of the velocity state.
     """
     return A * a * u - 2 * a * v - a ** 2 * x
 
@@ -69,21 +81,27 @@ def sigmoid(
     v0: Array,
     r: Array
 ) -> Array:
-    """
-    Sigmoidal firing rate function.
+    r"""Convert membrane potential to firing rate via a sigmoid.
 
-    Converts membrane potential to firing rate using a sigmoid function.
+    .. math::
 
-    S(x) = vmax / (1 + exp(r·(v0 - x)))
+        S(x) = \frac{v_{max}}{1 + \exp\!\big(r (v_0 - x)\big)}
 
-    Args:
-        x: Input membrane potential.
-        vmax: Maximum firing rate.
-        v0: Firing threshold (potential at half-max rate).
-        r: Steepness of the sigmoid.
+    Parameters
+    ----------
+    x : Array
+        Input membrane potential.
+    vmax : Array
+        Maximum firing rate.
+    v0 : Array
+        Firing threshold (potential at half-maximum rate).
+    r : Array
+        Steepness of the sigmoid.
 
-    Returns:
-        Firing rate in range (0, vmax).
+    Returns
+    -------
+    Array
+        Firing rate in the open interval ``(0, vmax)``.
     """
     # vmax / (1 + u.math.exp(r * (v0 - x)))
     return vmax * u.math.sigmoid(-r * (v0 - x))
@@ -93,18 +111,22 @@ def bounded_input(
     x: Array,
     bound: float = 500.0
 ) -> Array:
-    """
-    Apply tanh bounding to input signal.
+    r"""Apply a ``tanh`` bound to an input signal.
 
-    Prevents numerical instability by limiting the magnitude of inputs
-    to the second-order system.
+    Prevents numerical instability by smoothly limiting the magnitude of the
+    inputs fed to a second-order system.
 
-    Args:
-        x: Input signal.
-        bound: Maximum absolute value.
+    Parameters
+    ----------
+    x : Array
+        Input signal.
+    bound : float, default 500.0
+        Maximum absolute value of the output.
 
-    Returns:
-        Bounded input: bound * tanh(u / bound)
+    Returns
+    -------
+    Array
+        The bounded input ``bound * tanh(x / bound)``.
     """
     return bound * u.math.tanh(x / bound)
 
@@ -113,35 +135,47 @@ def process_sequence(
     data: brainstate.typing.PyTree,
     mode: Union[str, Callable] = 'stack',
 ) -> Union[Array, Tuple, List, Dict, Sequence]:
-    """
-    Stack a sequence of data items along a new dimension.
+    """Aggregate a sequence of data items along the leading dimension.
 
-    This is the inverse operation of slice_data - while slice_data reduces
-    a dimension via aggregation, stack_data creates a new dimension by
-    stacking multiple items together.
+    The sequence is first stacked along a new leading axis and then reduced
+    according to ``mode``. The reduction is applied recursively over arbitrary
+    PyTrees (dicts, tuples, lists, and nested combinations thereof).
 
+    Parameters
+    ----------
+    data : PyTree
+        A stacked PyTree of items, with the items enumerated along the leading
+        axis of every leaf. All leaves must share a compatible structure.
+    mode : str or Callable, default 'stack'
+        How to reduce along the leading axis:
 
-    Returns:
-        Aggregated data with structure matching input elements:
-        - mode='stack': Array/dict/tuple/list with new dimension at `dim`
-        - mode='last'/'first': Single item (same as data[-1] or data[0])
-        - mode='avg'/'mean'/'max'/'min': Aggregated tensor/dict/tuple/list
-        - mode=callable: Result of applying callable to stacked data
-        For dicts/tuples/lists, aggregation is applied recursively to each element.
+        - ``'stack'`` : return the data unchanged (identity).
+        - ``'last'`` / ``'first'`` : take the last/first item.
+        - ``'avg'`` / ``'mean'`` : mean over the leading axis.
+        - ``'max'`` / ``'min'`` : max/min over the leading axis.
+        - callable : apply the callable to each leaf.
 
-    Raises:
-        ValueError: If data is empty (cannot infer structure/type) or if
-            mode is an unknown string.
-        TypeError: If sequence contains mixed or incompatible types, or if
-            mode is not a string or callable.
+    Returns
+    -------
+    Array or tuple or list or dict or Sequence
+        Aggregated data whose structure matches the input leaves:
 
+        - ``mode='stack'`` : structure with the new leading dimension retained.
+        - ``mode='last'`` / ``'first'`` : a single item.
+        - ``mode='avg'``/``'mean'``/``'max'``/``'min'`` : reduced PyTree.
+        - ``mode`` callable : the result of applying the callable.
 
-    Notes:
-        - All elements in data must have the same type and structure
-        - NumPy arrays are automatically converted to float32 tensors
-        - Dictionary keys must match across all elements
-        - Tuple/list lengths must match across all elements
-        - Recursive: handles nested structures (e.g., dict of tuples)
+    Raises
+    ------
+    ValueError
+        If ``mode`` is an unknown string.
+
+    Notes
+    -----
+    - All leaves must share the same type and structure.
+    - Dictionary keys (and tuple/list lengths) must match across elements.
+    - The reduction is recursive and handles nested structures, e.g. a dict of
+      tuples of arrays.
     """
     msg = (
         f"Unknown mode: {mode}. "
@@ -171,6 +205,19 @@ def process_sequence(
 
 
 def set_module_as(module: str):
+    """Return a decorator that rebinds a function's ``__module__`` attribute.
+
+    Parameters
+    ----------
+    module : str
+        The module path to assign to the decorated function's ``__module__``.
+
+    Returns
+    -------
+    Callable
+        A decorator that sets ``fun.__module__ = module`` and returns ``fun``.
+    """
+
     def wrapper(fun: Callable):
         fun.__module__ = module
         return fun
@@ -179,4 +226,18 @@ def set_module_as(module: str):
 
 
 def delay_index(n_hidden: int):
+    """Build the neuron-index matrix used to address per-connection delays.
+
+    Parameters
+    ----------
+    n_hidden : int
+        Number of hidden units (nodes).
+
+    Returns
+    -------
+    numpy.ndarray
+        An integer array of shape ``(n_hidden, n_hidden)`` whose every row is
+        ``arange(n_hidden)``; row ``i`` selects the source-neuron index for
+        each delayed connection into target ``i``.
+    """
     return np.tile(np.expand_dims(np.arange(n_hidden), axis=0), (n_hidden, 1))

--- a/brainmass/utils_test.py
+++ b/brainmass/utils_test.py
@@ -1,0 +1,115 @@
+# Copyright 2025 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainunit as u
+
+from brainmass.utils import (
+    sys2nd, sigmoid, bounded_input, process_sequence, set_module_as, delay_index,
+)
+
+
+class TestSys2nd:
+    def test_acceleration_formula(self):
+        # dv/dt = A*a*u - 2*a*v - a**2 * x
+        A, a, inp, x, v = 2.0, 3.0, 1.0, 0.5, 0.25
+        out = sys2nd(A, a, inp, x, v)
+        assert np.isclose(out, A * a * inp - 2 * a * v - a ** 2 * x)
+
+
+class TestSigmoid:
+    def test_half_max_at_threshold(self):
+        # At x == v0 the argument is 0 -> sigmoid(0) = 0.5 -> vmax/2.
+        out = sigmoid(jnp.asarray(1.0), vmax=10.0, v0=1.0, r=0.5)
+        assert np.isclose(float(out), 5.0)
+
+    def test_monotonic_and_bounded(self):
+        xs = jnp.linspace(-10, 10, 50)
+        ys = np.asarray(sigmoid(xs, vmax=5.0, v0=0.0, r=1.0))
+        assert np.all(ys > 0) and np.all(ys < 5.0)
+        assert np.all(np.diff(ys) >= -1e-6)  # non-decreasing
+
+
+class TestBoundedInput:
+    def test_saturates_for_large_input(self):
+        out = bounded_input(jnp.asarray(1e6), bound=500.0)
+        assert np.isclose(float(out), 500.0, atol=1e-3)
+
+    def test_approx_linear_for_small_input(self):
+        out = bounded_input(jnp.asarray(1.0), bound=500.0)
+        assert np.isclose(float(out), 1.0, atol=1e-2)
+
+
+class TestProcessSequence:
+    def setup_method(self):
+        self.data = jnp.asarray(np.arange(12, dtype='float32').reshape(4, 3))
+
+    def test_stack_identity(self):
+        out = process_sequence(self.data, mode='stack')
+        assert out.shape == (4, 3)
+        assert np.allclose(np.asarray(out), np.asarray(self.data))
+
+    def test_first_and_last(self):
+        assert np.allclose(np.asarray(process_sequence(self.data, 'first')), np.asarray(self.data[0]))
+        assert np.allclose(np.asarray(process_sequence(self.data, 'last')), np.asarray(self.data[-1]))
+
+    @pytest.mark.parametrize('mode', ['avg', 'mean'])
+    def test_mean(self, mode):
+        out = process_sequence(self.data, mode)
+        assert np.allclose(np.asarray(out), np.asarray(self.data).mean(axis=0))
+
+    def test_max_min(self):
+        assert np.allclose(np.asarray(process_sequence(self.data, 'max')), np.asarray(self.data).max(axis=0))
+        assert np.allclose(np.asarray(process_sequence(self.data, 'min')), np.asarray(self.data).min(axis=0))
+
+    def test_callable_mode(self):
+        out = process_sequence(self.data, mode=lambda x: x.sum(axis=0))
+        assert np.allclose(np.asarray(out), np.asarray(self.data).sum(axis=0))
+
+    def test_pytree_dict(self):
+        tree = {'a': self.data, 'b': self.data + 1}
+        out = process_sequence(tree, 'mean')
+        assert set(out.keys()) == {'a', 'b'}
+        assert np.allclose(np.asarray(out['a']), np.asarray(self.data).mean(axis=0))
+
+    def test_unknown_string_mode_raises(self):
+        with pytest.raises(ValueError):
+            process_sequence(self.data, mode='nonsense')
+
+    def test_non_str_non_callable_mode_raises(self):
+        with pytest.raises(ValueError):
+            process_sequence(self.data, mode=123)
+
+
+class TestSetModuleAs:
+    def test_sets_dunder_module(self):
+        @set_module_as('brainmass.somewhere')
+        def fn():
+            return 1
+
+        assert fn.__module__ == 'brainmass.somewhere'
+        assert fn() == 1
+
+
+class TestDelayIndex:
+    def test_shape_and_rows(self):
+        idx = delay_index(4)
+        assert idx.shape == (4, 4)
+        # every row is arange(n)
+        for row in idx:
+            assert list(row) == [0, 1, 2, 3]

--- a/brainmass/wong_wang.py
+++ b/brainmass/wong_wang.py
@@ -28,102 +28,103 @@ __all__ = [
 
 
 class WongWangStep(brainstate.nn.Dynamics):
-    r"""
-    The Wong-Wang neural mass model for perceptual decision-making.
-    
-    This model implements the reduced two-variable neural mass model described in:
-    Wong, K.-F. & Wang, X.-J. "A Recurrent Network Mechanism of Time Integration 
-    in Perceptual Decisions." J. Neurosci. 26, 1314–1328 (2006).
-    
-    The model describes the competitive dynamics between two neural populations 
-    (e.g., left vs right motion detection) through slow NMDA-mediated recurrent 
-    excitation, capturing the temporal integration of sensory evidence during 
+    r"""Wong-Wang reduced neural-mass model for perceptual decision-making.
+
+    Implements the reduced two-variable model of Wong & Wang (2006). It
+    describes the competitive dynamics between two neural populations (e.g.
+    left- vs right-motion detectors) through slow NMDA-mediated recurrent
+    excitation, capturing the temporal integration of sensory evidence during
     perceptual decision-making.
 
-    Mathematical Description
-    ========================
-    
-    The model is governed by two coupled differential equations for the synaptic 
-    gating variables S1 and S2 of the competing neural populations:
-    
+    Parameters
+    ----------
+    in_size : brainstate.typing.Size
+        Shape of the population (number of independent decision units).
+    tau_S : Parameter, default ``0.1 * u.second``
+        NMDA receptor time constant.
+    gamma : Parameter, default 0.641
+        Saturation factor for the synaptic gating variables.
+    a : Parameter, default ``270. * (u.Hz / u.nA)``
+        Gain of the input-output (f-I) function.
+    theta : Parameter, default ``0.31 * u.nA``
+        Firing threshold of the input-output function.
+    J_N11 : Parameter, default ``0.2609 * u.nA``
+        Self-excitation strength of population 1.
+    J_N22 : Parameter, default ``0.2609 * u.nA``
+        Self-excitation strength of population 2.
+    J_N12 : Parameter, default ``0.0497 * u.nA``
+        Cross-inhibition strength from population 2 to population 1.
+    J_N21 : Parameter, default ``0.0497 * u.nA``
+        Cross-inhibition strength from population 1 to population 2.
+    J_A_ext : Parameter, default ``0.0002243 * (u.nA / u.Hz)``
+        External input strength (AMPA).
+    mu_0 : Parameter, default ``30. * u.Hz``
+        Baseline external input rate.
+    I_0 : Parameter, default ``0.3255 * u.nA``
+        Background input current.
+    noise_s1 : Noise, optional
+        Noise process added to the input current of population 1. ``None``
+        disables noise on that population.
+    noise_s2 : Noise, optional
+        Noise process added to the input current of population 2. ``None``
+        disables noise on that population.
+
+    Notes
+    -----
+    The model evolves the synaptic gating variables :math:`S_1` and :math:`S_2`
+    of the two competing populations:
+
     .. math::
-        \frac{dS_1}{dt} = -\frac{S_1}{\tau_S} + (1-S_1)\gamma r_1
-        
+
+        \frac{dS_1}{dt} = -\frac{S_1}{\tau_S} + (1-S_1)\gamma r_1 , \qquad
+        \frac{dS_2}{dt} = -\frac{S_2}{\tau_S} + (1-S_2)\gamma r_2 ,
+
+    where the firing rates follow the threshold-linear f-I curve
+
     .. math::
-        \frac{dS_2}{dt} = -\frac{S_2}{\tau_S} + (1-S_2)\gamma r_2
-    
-    where the firing rates r1 and r2 are given by:
-    
-    .. math::
+
         r_i = \phi(I_i) = \begin{cases}
             a(I_i - \theta) & \text{if } I_i > \theta \\
-            0 & \text{otherwise}
+            0 & \text{otherwise} ,
         \end{cases}
-    
-    The total input current to each population is:
-    
+
+    and the total input currents are
+
     .. math::
-        I_1 = J_{N,11}S_1 - J_{N,12}S_2 + J_{A,ext}\mu_0(1+c) + I_{noise,1}
-        
+
+        I_1 = J_{N,11}S_1 - J_{N,12}S_2 + J_{A,ext}\mu_0(1+c) + I_0 + I_{noise,1} ,
+
     .. math::
-        I_2 = J_{N,22}S_2 - J_{N,21}S_1 + J_{A,ext}\mu_0(1-c) + I_{noise,2}
 
-    Parameters
-    ==========
-    
-    Synaptic Parameters:
-        - $\tau_S$ = 100 ms : NMDA receptor time constant
-        - $\gamma$ = 0.641 : Saturation factor for synaptic gating
-        
-    Input-Output Function:
-        - $\alpha$ = 270 Hz/nA : Gain parameter
-        - $\theta$ = 0.31 nA : Firing threshold
-        
-    Network Connectivity (typical values):
-        - J_N,11 = J_N,22 = 0.2609 nA : Self-excitation strength
-        - J_N,12 = J_N,21 = 0.0497 nA : Cross-inhibition strength
-        - J_A,ext = 0.00052 nA : External input strength
-        
-    External Input:
-        - $\mu_0$ = 30 Hz : Baseline external input rate
-        - $c \in [-1, 1]$ : Motion coherence (stimulus strength)
+        I_2 = J_{N,22}S_2 - J_{N,21}S_1 + J_{A,ext}\mu_0(1-c) + I_0 + I_{noise,2} ,
 
+    with motion coherence :math:`c \in [-1, 1]`.
 
-    Network Behavior
-    ================
-    
-    The model exhibits rich dynamics depending on the stimulus strength:
-    
-    1. **Spontaneous State**: At c=0 (no coherence), both populations have equal 
-       activity, representing uncertainty.
-       
-    2. **Decision State**: For $|c| > 0$, one population gradually wins the competition,
-       representing a perceptual choice.
-       
-    3. **Bistability**: The network can exhibit bistable attractor dynamics where
-       the system can remain in either of two decision states.
-       
-    4. **Integration Time**: The slow NMDA dynamics ($\tau_S$ = 100ms) enable temporal
-       integration of sensory evidence over hundreds of milliseconds.
+    The network exhibits a spontaneous (symmetric) state at :math:`c = 0`, a
+    decision state in which one population wins for :math:`|c| > 0`, bistable
+    attractor dynamics, and slow (:math:`\tau_S = 100` ms) temporal integration
+    of evidence over hundreds of milliseconds.
 
-
-    Usage Example
-    =============
-    
-    >>> model = WongWangStep(in_size=100)
-    >>> model.init_all_states(batch_size=1)
-    >>> 
-    >>> # Simulate decision making with rightward motion (c=0.32)
-    >>> for t in range(1000):
-    ...     output = model.update(coherence=0.32)
-    ...     # S1 and S2 activities accessible via model.S1.value, model.S2.value
-    
     References
-    ==========
-    
-    - Wong, K.-F. & Wang, X.-J. A Recurrent Network Mechanism of Time Integration 
-      in Perceptual Decisions. J. Neurosci. 26, 1314–1328 (2006).
-    - Deco, G. et al. The role of rhythm in cognition. Front. Hum. Neurosci. 5, 29 (2011).
+    ----------
+    .. [1] Wong, K.-F. & Wang, X.-J. "A Recurrent Network Mechanism of Time
+           Integration in Perceptual Decisions." J. Neurosci. 26, 1314-1328
+           (2006).
+    .. [2] Deco, G. et al. "The role of rhythm in cognition." Front. Hum.
+           Neurosci. 5, 29 (2011).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import brainmass
+        >>> model = brainmass.WongWangStep(in_size=100)
+        >>> model.init_all_states(batch_size=1)
+        >>> # Simulate decision-making with rightward motion (c=0.32).
+        >>> for t in range(1000):
+        ...     r1, r2 = model.update(coherence=0.32)
+        >>> # S1 and S2 activities are accessible via model.S1.value / model.S2.value.
     """
     __module__ = 'brainmass'
 
@@ -135,7 +136,7 @@ class WongWangStep(brainstate.nn.Dynamics):
         tau_S: Parameter = 0.1 * u.second,  # NMDA time constant (ms)
         gamma: Parameter = 0.641,  # saturation factor
 
-        # Input-output function parameters  
+        # Input-output function parameters
         a: Parameter = 270. * (u.Hz / u.nA),  # gain (Hz/nA)
         theta: Parameter = 0.31 * u.nA,  # firing threshold (nA)
 
@@ -185,30 +186,41 @@ class WongWangStep(brainstate.nn.Dynamics):
         self.S2 = brainstate.HiddenState.init(jnp.zeros, self.varshape, batch_size)
 
     def phi(self, I):
-        """
-        Input-output transfer function (f-I curve).
-        
-        Args:
-            I: Input current (nA)
-            
-        Returns:
-            Firing rate (Hz)
+        """Threshold-linear input-output transfer function (f-I curve).
+
+        Parameters
+        ----------
+        I : ArrayLike
+            Input current (in units of ``nA``).
+
+        Returns
+        -------
+        ArrayLike
+            Firing rate (in units of ``Hz``); ``a * (I - theta)`` above
+            threshold and ``0`` otherwise.
         """
         theta = self.theta.value()
         a = self.a.value()
         return u.math.where(I > theta, a * (I - theta), 0. * u.Hz)
 
     def compute_inputs(self, coherence=0., noise_1_val=0. * u.nA, noise_2_val=0. * u.nA):
-        """
-        Compute total input currents to both populations.
-        
-        Args:
-            coherence: Motion coherence level, c ∈ [-1, 1]
-            noise_1_val: Noise input to population 1
-            noise_2_val: Noise input to population 2
-            
-        Returns:
-            Tuple of (I1, I2) input currents
+        """Compute the total input currents to both populations.
+
+        Parameters
+        ----------
+        coherence : float, default 0.0
+            Motion coherence level, ``c`` in ``[-1, 1]``.
+        noise_1_val : ArrayLike, default ``0. * u.nA``
+            Noise input added to population 1.
+        noise_2_val : ArrayLike, default ``0. * u.nA``
+            Noise input added to population 2.
+
+        Returns
+        -------
+        I1 : ArrayLike
+            Total input current to population 1.
+        I2 : ArrayLike
+            Total input current to population 2.
         """
         J_A_ext = self.J_A_ext.value()
         mu_0 = self.mu_0.value()
@@ -245,15 +257,20 @@ class WongWangStep(brainstate.nn.Dynamics):
         return (-S2 / tau_S + (1 - S2) * gamma * r2).to(u.Hz)
 
     def update(self, coherence=0.):
-        """
-        Update the Wong-Wang model for one time step.
-        
-        Args:
-            coherence: Motion coherence level, c ∈ [-1, 1]. Positive values 
-                      favor population 1, negative values favor population 2.
+        """Advance the Wong-Wang model by one time step.
 
-        Returns:
-            Tuple of (r1, r2) firing rates of the two populations
+        Parameters
+        ----------
+        coherence : float, default 0.0
+            Motion coherence level, ``c`` in ``[-1, 1]``. Positive values
+            favour population 1, negative values favour population 2.
+
+        Returns
+        -------
+        r1 : ArrayLike
+            Firing rate of population 1 (in units of ``Hz``).
+        r2 : ArrayLike
+            Firing rate of population 2 (in units of ``Hz``).
         """
         # Add noise if specified
         noise_1_val = 0. * u.nA if self.noise_s1 is None else self.noise_s1()
@@ -277,14 +294,19 @@ class WongWangStep(brainstate.nn.Dynamics):
         return r1, r2
 
     def get_decision(self, threshold=15. * u.Hz):
-        """
-        Get the current decision based on firing rate threshold.
-        
-        Args:
-            threshold: Firing rate threshold for decision (Hz)
-            
-        Returns:
-            Decision: 1 if population 1 wins, -1 if population 2 wins, 0 if undecided
+        """Return the current decision based on a firing-rate threshold.
+
+        Parameters
+        ----------
+        threshold : ArrayLike, default ``15. * u.Hz``
+            Firing-rate threshold a population must exceed to count as the
+            winner.
+
+        Returns
+        -------
+        ArrayLike
+            Decision code: ``1`` if population 1 wins, ``-1`` if population 2
+            wins, and ``0`` if undecided.
         """
         I1, I2 = self.compute_inputs()
         r1 = self.phi(I1)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+"""Pytest configuration for the brainmass test suite.
+
+Forces matplotlib onto the non-interactive ``Agg`` backend so the demo tests
+(``test_demo_*``, which default to ``plot=True`` and call ``plt.show()``) never
+open a blocking GUI window. Under ``Agg`` the ``plt.show()`` call is a
+non-blocking no-op, so ``pytest brainmass/`` runs unattended in CI and headless
+shells instead of hanging until each figure window is closed by hand.
+"""
+
+import matplotlib
+
+# Must run before any ``import matplotlib.pyplot`` performed by the test
+# modules. pytest imports conftest.py before it collects/imports the test
+# files, so selecting the backend here guarantees pyplot binds to ``Agg``.
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402  (import after backend selection)
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _close_matplotlib_figures():
+    """Close every open figure after each test.
+
+    Yields control to the test, then closes all figures so a long session does
+    not trip matplotlib's "More than 20 figures have been opened" warning or
+    leak figure memory across tests.
+    """
+    yield
+    plt.close("all")


### PR DESCRIPTION
## Summary

Goal-01 (code correctness). Each bug fixed via TDD (reproduce → fix); low-risk debt cleaned up; coverage raised on every touched file.

### Bugs fixed
- **coupling.py** — `LaplacianConnParam` had a method/attribute name collision (`normalize`). Renamed the method to `_laplacian` and pass it as `precompute=`; the `normalize` mode string now stands alone.
- **jansen_rit.py** — `JansenRitTR.update` referenced `inp_*_tr` before assignment; hoisted `conn.update_tr()` / `k*input` above the sub-step closure.
- **noise.py** — `BrownianNoise` increment now `sigma*sqrt(dt)*noise` (variance scales with dt; unit-safe). Fixed `BlueNoise` (PSD ∝ f²) and `VioletNoise` (PSD ∝ f⁴) beta signs.
- **forward_model.py** — fixed `LeadFieldModel` docstring/shape drift and the dangling `self._noise_cov_q` reference in `_sample_noise`.
- **jansen_rit.py** — `s_max` docstring corrected to match code & literature (`2·e₀ = 5 Hz`, Jansen & Rit 1995).

### Refactor / debt
- Deduplicated `AdditiveConn` / `DelayedAdditiveConn` into `coupling.py` (single source; shared by HORN `state='y'` and Jansen-Rit `state='M'`).
- Replaced `brainmass.delay_index` self-import in `jansen_rit.py` with the local symbol.
- Converted Google-style docstrings → NumPy-doc in `utils.py`, `leadfield.py`, `wong_wang.py`.
- Documented the leadfield overlap: keep both `LeadFieldModel` (unit-aware forward operator) and `LeadfieldReadout` (lightweight trainable head) with reciprocal "use X when" / See Also notes.

### Infra / tests
- Added root `conftest.py` forcing the matplotlib `Agg` backend + autouse close-all, so demo tests (`plot=True` / `plt.show()`) no longer block pytest.
- Added `horn_test.py`, `leadfield_test.py`, `utils_test.py`; extended coupling/noise/jansen_rit/forward_model tests.
- **Full suite: 229 passed, 1 xfailed.** Coverage ≥95% on all changed source files (forward_model / jansen_rit / leadfield / utils / wong_wang = 100%; coupling 95%, noise 96%, horn 99%).

### Documented (not changed) latent findings
- `LeadfieldReadout.normalize_leadfield` is labelled "L2" but computes the **L1** norm (`sum(|w|)`). Numerics left unchanged; docstring/comment/test corrected to L1. Flagged for maintainer decision.
- `JansenRitNetwork` **multi-layer** chaining hits a unit mismatch (a layer emits an mV `Quantity`, the next re-multiplies by `u.mV`). Single-layer works; multi-layer test marked `xfail(strict)`.

See `CONTEXT.md` lessons ledger for details.