### PR TITLE
docs: documentation integrity — kill API drift, make docs self-checking (goal-02)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -134,3 +134,54 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
     from-CWD. (Recovered with `git -C <main> checkout HEAD -- <file>`.)
   - Bumpy `Edit`-tool persistence was observed on drvfs earlier; `Write` (whole-file) and
     Bash read-modify-write (`.count()==1` guard) are reliable.
+
+### 2026-06-18 · goal-02 docs-integrity
+- **API drift killed (grep over `docs/` + README now empty):** renamed every legacy class
+  reference to its canonical `*Step` (`HopfOscillator`→`HopfStep`, `WilsonCowanModel`→
+  `WilsonCowanStep`, `WongWangModel`→`WongWangStep`, `JansenRitModel`→`JansenRitStep`,
+  `FitzHughNagumoModel`→`FitzHughNagumoStep`, `ThresholdLinearModel`→`ThresholdLinearStep`,
+  `StuartLandauOscillator`→`StuartLandauStep`, `VanDerPolOscillator`→`VanDerPolStep`,
+  `QIF`/`QIFModel`→`MontbrioPazoRoxinStep`). Left untouched: real classes (`LeadFieldModel`,
+  EEG/MEG), pedagogical placeholders (`MyModel`/`CustomOscillator`), HORN's real `omega`
+  param, Kuramoto's `omega_mean`/`omega_std`, and **historical changelog entries** (0.0.4/0.0.5
+  legitimately shipped the old names — do NOT rewrite release notes; the DoD grep is scoped to
+  the live `docs/` tree, not `changelog.md`).
+- **`HopfStep` has no `omega`/`u.Hz` arg** — it takes a *dimensionless* `w` (normal-form angular
+  frequency). All `HopfStep(omega=…*u.Hz)` calls in docs were never-runnable; fixed to `w=`.
+- **Real `DiffusiveCoupling` API** (docs were full of the imagined `DiffusiveCoupling(conn=W,k=)`
+  + `coupling(src,tgt)` form): construct from prefetch refs —
+  `nodes.prefetch_delay('x', delays, src_idx, init=braintools.init.ZeroInit())` (gives the
+  `(N,N)` source read the impl REQUIRES) + `nodes.prefetch('x')` (the `(N,)` self read), then
+  `DiffusiveCoupling(x_src, x_self, conn=W, k=…)`; drive with `coupling.update()` inside
+  `environ.context(i=,t=)`. A plain `(N,)` source read raises `incompatible shape … expected
+  (...,N,N)`. Verified runnable in quickstart + building_networks + adding_coupling.
+- **Imagined whole-brain API still littering tutorials (NOT a real API):** `nodes.S_E.value`,
+  `nodes.update(S_E_ext=…)`, `nodes.noise_E=…` assume a Wong-Wang/DMF that doesn't exist
+  (`WongWangStep` has `S1`/`S2`, `update(coherence=)`, `noise_s1`/`noise_s2`). These live in the
+  data-dependent tutorials (forward_modeling, parameter_fitting, building_networks whole-brain
+  example) — marked **schematic / not executed** with a `.. note::` per the goal's allowance,
+  rather than rewritten. A future orchestration goal (06–08) that adds a real `Network`/`Simulator`
+  should revisit and make them runnable.
+- **Docs are now self-checking via `sphinx.ext.doctest`** (lightest robust option chosen over
+  notebook execution, which stays `nb_execution_mode="off"`). Key mechanics:
+  - `.. testcode::` = execute-only (no output match); bare `>>>` napoleon blocks ARE checked
+    for output because `doctest_test_doctest_blocks = "default"`. `.. code-block:: python` with
+    `>>>` is NOT tested — only bare doctest blocks and `testcode` are.
+  - `doctest_global_setup` imports ONLY `brainmass` (+ brainstate/u/jax/np/plt, `Agg`, `dt`).
+    So docstring `>>>` examples MUST be self-contained: qualify `brainmass.HORNSeqNetwork`, not
+    bare `HORNSeqNetwork`. **`doctest.DocTestFinder` over the package gives FALSE PASSES here** —
+    it uses each module's own globals (bare class names resolve), so it missed `horn.py`'s bare
+    `HORNSeqNetwork`. `sphinx-build -b doctest docs docs/_build/doctest` is the ONLY authoritative
+    gate. Final: **48 tests, 0 failures**.
+  - In bare `>>>` blocks, `init_all_states()`/`brainstate.nn.init_all_states(m)` RETURN the module
+    (repr prints → doctest mismatch). Capture with `_ = …`. (In `.. testcode::` it's harmless.)
+- **Deliverables:** README runnable Quick Start + citation `0.0.4`→`0.0.6`; `changelog.md` 0.0.6
+  entry (goal-01 fixes + this docs work); `contributing.rst` corrected (NumPy not Google
+  docstrings; no `tests/` dir — tests are co-located `brainmass/<m>_test.py`, `pytest brainmass/`;
+  `.[dev,doc]` extras don't exist yet → install via `requirements-doc.txt`, consolidated extras
+  are goal-03); `conf.py` single `autodoc_default_options`. `pytest brainmass/` still green
+  (229 passed, 1 xfailed).
+- **Gotcha for next goal:** the manual git worktree at `.claude/worktrees/goal-02-docs-integrity`
+  must be committed-to early — a native/empty worktree got auto-cleaned ("unchanged") mid-session.
+  And the same drvfs absolute-path trap as goal-01: file tools with an absolute path to the MAIN
+  checkout write to main, not the worktree.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,38 @@ pip install BrainX[tpu]
 ```
 
 
+## Quick Start
+
+Simulate a single brain region with the Hopf oscillator model. The integration time step
+``dt`` is global state set once through ``brainstate.environ`` -- it is **not** a model argument:
+
+```python
+import brainmass
+import brainstate
+import brainunit as u
+import numpy as np
+
+# dt is a global, set once through the environment (not a model argument)
+brainstate.environ.set(dt=0.1 * u.ms)
+
+# Create a single-region Hopf oscillator in the limit-cycle regime (a > 0)
+model = brainmass.HopfStep(in_size=1, a=0.25, w=0.2)
+model.init_all_states()
+
+# Advance the model one step at a time, recording the x-coordinate
+def step(i):
+    with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+        model.update()
+        return model.x.value
+
+x = brainstate.transform.for_loop(step, np.arange(1000))
+print(x.shape)  # (1000, 1)
+```
+
+See the [Quickstart tutorial](https://brainx.chaobrain.com/brainmass/tutorials/quickstart.html)
+for noise, multi-region networks, coupling, and forward (BOLD/EEG/MEG) modeling.
+
+
 ## Citation
 
 If you use BrainMass in your research, please cite:
@@ -71,7 +103,7 @@ If you use BrainMass in your research, please cite:
   title={BrainMass: Whole-brain modeling with differentiable neural mass models},
   author={BrainMass Developers},
   url={https://github.com/chaobrain/brainmass},
-  version={0.0.4},
+  version={0.0.6},
   year={2025}
 }
 ```

--- a/brainmass/coupling.py
+++ b/brainmass/coupling.py
@@ -398,23 +398,25 @@ def laplacian_connectivity(
 
     Examples
     --------
-    Compute unnormalized Laplacian for a simple 3-node graph:
+    Compute the (combinatorial) Laplacian for a simple 3-node graph:
 
+    >>> import brainmass
     >>> import brainunit as u
     >>> W = u.math.asarray([[0., 1., 1.],
     ...                      [1., 0., 1.],
     ...                      [1., 1., 0.]])
-    >>> L = laplacian_connectivity(W)
-    >>> # L = [[ 2, -1, -1],
-    >>> #      [-1,  2, -1],
-    >>> #      [-1, -1,  2]]
+    >>> L = brainmass.laplacian_connectivity(W)
+    >>> L.shape
+    (3, 3)
+    >>> # every row of the combinatorial Laplacian sums to zero
+    >>> bool(abs(L.sum(axis=1)).max() < 1e-6)
+    True
 
-    Compute symmetric normalized Laplacian:
+    Compute the symmetric normalized Laplacian:
 
-    >>> L_sym = laplacian_connectivity(W, normalize="sym")
-    >>> # L_sym = [[ 1.0, -0.5, -0.5],
-    >>> #          [-0.5,  1.0, -0.5],
-    >>> #          [-0.5, -0.5,  1.0]]
+    >>> L_sym = brainmass.laplacian_connectivity(W, normalize="sym")
+    >>> L_sym.shape
+    (3, 3)
     """
     W = u.math.asarray(W)
     d = u.math.sum(W, axis=-1)  # (N,)

--- a/brainmass/forward_model.py
+++ b/brainmass/forward_model.py
@@ -220,24 +220,35 @@ class LeadFieldModel(nn.Module):
 
     Examples
     --------
+    >>> import brainmass
     >>> import brainunit as u
     >>> import jax.numpy as jnp
+    >>> M, R, T = 64, 68, 200          # sensors, regions, time steps
 
-    >>> # constants
-    >>> M, R, T = 64, 68, 2000
+    EEG: lead field in V/(nA*m), shape ``(R, M)``.
 
-    >>> # EEG example: lead field in V/(nA*m)
-    >>> L = jnp.ones((R, M)) * u.volt / (u.nA * u.meter)
-    >>> # Suppose NMM observable is in mV; choose scale to map mV -> nA*m
-    >>> scale = 0.1 * u.nA * u.meter / u.volt     # toy number
-    >>> model = LeadFieldModel(L=L, scale=scale, sensor_unit=u.volt, dipole_unit=u.nA * u.meter)
-    >>> nmm_obs = 50.0 * jnp.ones((T, R)) * u.mV # (T, R) in mV
-    >>> y = model(nmm_obs)  # Quantity with unit "V", shape (T, M)
+    >>> L = jnp.ones((R, M)) * (u.volt / (u.nA * u.meter))
+    >>> model = brainmass.LeadFieldModel(
+    ...     in_size=(R,), out_size=(M,), L=L,
+    ...     sensor_unit=u.volt, dipole_unit=u.nA * u.meter,
+    ...     scale=0.1 * u.nA * u.meter / u.volt,   # map the (mV-scale) observable to a dipole moment
+    ... )
+    >>> nmm_obs = 50.0 * jnp.ones((T, R)) * u.mV   # region observable, (T, R)
+    >>> y = model.update(nmm_obs)                   # sensor-space signal, (T, M)
+    >>> y.shape
+    (200, 64)
 
-    >>> # MEG example: lead field in T/(nA*m)
-    >>> L_u = jnp.ones((R, M)) * u.tesla * (u.nA * u.meter)
-    >>> model_u = LeadFieldModel(L=L_u,  sensor_unit=u.volt, dipole_unit=u.nA*u.meter, scale=u.nA*u.meter/u.tesla)
-    >>> y2 = model_u(50.0 * jnp.ones((T, R)) * u.tesla)
+    MEG: lead field in T/(nA*m); use the tesla sensor unit.
+
+    >>> L_meg = jnp.ones((R, M)) * (u.tesla / (u.nA * u.meter))
+    >>> model_meg = brainmass.LeadFieldModel(
+    ...     in_size=(R,), out_size=(M,), L=L_meg,
+    ...     sensor_unit=u.tesla, dipole_unit=u.nA * u.meter,
+    ...     scale=0.1 * u.nA * u.meter / u.mV,
+    ... )
+    >>> y_meg = model_meg.update(50.0 * jnp.ones((T, R)) * u.mV)
+    >>> y_meg.shape
+    (200, 64)
 
 
     Parameters

--- a/brainmass/horn.py
+++ b/brainmass/horn.py
@@ -625,16 +625,22 @@ class HORNSeqNetwork(Module):
     --------
     Create a 2-layer HORN network for sequence classification:
 
+    >>> import brainmass
     >>> import brainstate
-    >>> net = HORNSeqNetwork(
+    >>> import brainunit as u
+    >>> brainstate.environ.set(dt=0.1 * u.ms)
+    >>> net = brainmass.HORNSeqNetwork(
     ...     n_input=10,
     ...     n_hidden=[64, 128],
     ...     n_output=5,
     ...     alpha=0.04,
-    ...     omega=2*3.14159/28
+    ...     omega=2 * 3.14159 / 28,
     ... )
+    >>> _ = brainstate.nn.init_all_states(net)
     >>> inputs = brainstate.random.randn(20, 10)  # (time_steps, input_dim)
-    >>> output = net(inputs)  # (output_dim,)
+    >>> output = net(inputs)
+    >>> output.shape
+    (5,)
     """
 
     def __init__(

--- a/brainmass/wilson_cowan.py
+++ b/brainmass/wilson_cowan.py
@@ -522,9 +522,15 @@ class WilsonCowanNoSaturationStep(WilsonCowanBase):
 
     Examples
     --------
+    >>> import brainmass
+    >>> import brainstate
+    >>> import brainunit as u
+    >>> brainstate.environ.set(dt=0.1 * u.ms)
     >>> model = brainmass.WilsonCowanNoSaturationStep(1)
-    >>> model.init_all_states()
-    >>> model.update(rE_inp=0.5)
+    >>> _ = model.init_all_states()
+    >>> out = model.update(rE_inp=0.5)
+    >>> out.shape
+    (1,)
     """
     __module__ = 'brainmass'
 
@@ -690,9 +696,15 @@ class WilsonCowanSymmetricStep(WilsonCowanBase):
 
     Examples
     --------
+    >>> import brainmass
+    >>> import brainstate
+    >>> import brainunit as u
+    >>> brainstate.environ.set(dt=0.1 * u.ms)
     >>> model = brainmass.WilsonCowanSymmetricStep(1)
-    >>> model.init_all_states()
-    >>> model.update(rE_inp=0.5)
+    >>> _ = model.init_all_states()
+    >>> out = model.update(rE_inp=0.5)
+    >>> out.shape
+    (1,)
     """
     __module__ = 'brainmass'
 
@@ -857,9 +869,15 @@ class WilsonCowanSimplifiedStep(WilsonCowanBase):
 
     Examples
     --------
+    >>> import brainmass
+    >>> import brainstate
+    >>> import brainunit as u
+    >>> brainstate.environ.set(dt=0.1 * u.ms)
     >>> model = brainmass.WilsonCowanSimplifiedStep(1)
-    >>> model.init_all_states()
-    >>> model.update(rE_inp=0.5)
+    >>> _ = model.init_all_states()
+    >>> out = model.update(rE_inp=0.5)
+    >>> out.shape
+    (1,)
     """
     __module__ = 'brainmass'
 
@@ -1020,9 +1038,15 @@ class WilsonCowanLinearStep(WilsonCowanBase):
 
     Examples
     --------
+    >>> import brainmass
+    >>> import brainstate
+    >>> import brainunit as u
+    >>> brainstate.environ.set(dt=0.1 * u.ms)
     >>> model = brainmass.WilsonCowanLinearStep(1)
-    >>> model.init_all_states()
-    >>> model.update(rE_inp=0.5)
+    >>> _ = model.init_all_states()
+    >>> out = model.update(rE_inp=0.5)
+    >>> out.shape
+    (1,)
     """
     __module__ = 'brainmass'
 

--- a/brainmass/wong_wang.py
+++ b/brainmass/wong_wang.py
@@ -115,16 +115,17 @@ class WongWangStep(brainstate.nn.Dynamics):
 
     Examples
     --------
-    .. code-block:: python
-
-        >>> import brainstate
-        >>> import brainmass
-        >>> model = brainmass.WongWangStep(in_size=100)
-        >>> model.init_all_states(batch_size=1)
-        >>> # Simulate decision-making with rightward motion (c=0.32).
-        >>> for t in range(1000):
-        ...     r1, r2 = model.update(coherence=0.32)
-        >>> # S1 and S2 activities are accessible via model.S1.value / model.S2.value.
+    >>> import brainmass
+    >>> import brainstate
+    >>> import brainunit as u
+    >>> brainstate.environ.set(dt=0.1 * u.ms)
+    >>> model = brainmass.WongWangStep(in_size=2)
+    >>> _ = model.init_all_states()
+    >>> # one decision-making step with rightward motion coherence c=0.32
+    >>> r1, r2 = model.update(coherence=0.32)   # population firing rates (Hz)
+    >>> r1.shape
+    (2,)
+    >>> # S1 and S2 synaptic gating are accessible via model.S1.value / model.S2.value
     """
     __module__ = 'brainmass'
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,51 @@
 # Release Notes
 
+## Version 0.0.6 (2026-06-18)
+
+### Bug Fixes
+
+- `coupling.py` — fixed a method/attribute name collision in `LaplacianConnParam` (the
+  `normalize` precompute method shadowed the `normalize` mode string) that broke Laplacian
+  connectivity normalization when it was actually exercised.
+- `jansen_rit.py` `JansenRitTR.update` — fixed the time-resolution sub-step closure, which
+  read `inp_M_tr`/`inp_E_tr`/`inp_I_tr` before they were assigned (it only worked by a
+  late-binding accident).
+- `noise.py` `BrownianNoise.update` — corrected the increment scaling so variance grows with
+  `dt` (`sigma * sqrt(dt) * noise`) instead of collapsing to `sigma`.
+- `noise.py` colored noise — corrected the spectral exponents of `BlueNoise` and
+  `VioletNoise` to be consistent with the `1/f^β` definitions and their docstrings.
+- `forward_model.py` `LeadFieldModel` — fixed docstring/shape drift and a dangling
+  `self._noise_cov_q` reference in `_sample_noise` (the Cholesky factor `_noise_conv_Lc`).
+- `jansen_rit.py` — corrected the `s_max` docstring (2.5 Hz → 5.0 Hz) to match the code and
+  the literature value `2·e0` (Jansen & Rit 1995).
+
+### Code Quality
+
+- Deduplicated the `AdditiveConn`/`DelayedAdditiveConn` recurrent-connection classes into a
+  single source of truth in `coupling.py`.
+- Replaced a `brainmass.delay_index` self-import in `jansen_rit.py` with the local definition.
+- Converted remaining Google-style docstrings to NumPy style (`utils.py`, `leadfield.py`,
+  `wong_wang.py`) and documented when to use `LeadFieldModel` (unit-aware physical forward
+  operator) versus `LeadfieldReadout` (lightweight trainable EEG head).
+
+### Documentation
+
+- Eliminated API drift across the documentation: every legacy `*Oscillator`/`*Model`/`QIF`
+  class reference now uses its canonical `*Step` name (e.g. `HopfOscillator` → `HopfStep`,
+  `WilsonCowanModel` → `WilsonCowanStep`, `QIF` → `MontbrioPazoRoxinStep`).
+- Rewrote the Quickstart and other hero examples to run against the current API, and enabled
+  `sphinx.ext.doctest` so docstring examples and key tutorial snippets are executed and
+  verified at build time. Data-dependent tutorials are explicitly marked as non-executed.
+- Merged the duplicated `autodoc_default_options` in `docs/conf.py` (the second definition
+  had been silently disabling member documentation).
+- Added a runnable Quick Start snippet to the README and corrected the citation version to
+  match the package version.
+
+### Tests
+
+- Added regression tests (written test-first) covering the corrected coupling, Jansen-Rit,
+  noise, and forward-model behavior.
+
 ## Version 0.0.5 (2026-01-07)
 
 ### Core Architecture

--- a/docs/api/coupling.rst
+++ b/docs/api/coupling.rst
@@ -117,7 +117,7 @@ Class-Based Coupling
    coupling.init_all_states()
 
    # Create node dynamics
-   nodes = brainmass.HopfOscillator(in_size=N, omega=10 * u.Hz)
+   nodes = brainmass.HopfStep(in_size=N, w=0.3)
    nodes.init_all_states()
 
    # Simulation loop
@@ -212,7 +212,7 @@ Basic Network Simulation
    W = W.at[jnp.diag_indices(N_regions)].set(0.)
 
    # Create network components
-   nodes = brainmass.WilsonCowanModel(in_size=N_regions)
+   nodes = brainmass.WilsonCowanStep(in_size=N_regions)
    coupling = brainmass.DiffusiveCoupling(conn=W, k=coupling_strength)
 
    # Add noise

--- a/docs/api/forward.rst
+++ b/docs/api/forward.rst
@@ -85,7 +85,7 @@ The BOLD signal is then computed from volume and deoxyhemoglobin:
    N_regions = 10
 
    # Create neural mass model
-   nmm = brainmass.WilsonCowanModel(in_size=N_regions)
+   nmm = brainmass.WilsonCowanStep(in_size=N_regions)
    nmm.init_all_states()
 
    # Create BOLD forward model
@@ -243,7 +243,7 @@ fMRI BOLD Simulation
    T = 600  # 10 minutes at 1 ms resolution
 
    # 1. Create neural mass model
-   nodes = brainmass.HopfOscillator(in_size=N, omega=10 * u.Hz, a=0.1)
+   nodes = brainmass.HopfStep(in_size=N, w=0.3, a=0.1)
 
    # 2. Add coupling
    W = jnp.load('structural_connectivity.npy')  # DTI tractography
@@ -299,7 +299,7 @@ EEG/MEG Source Space Simulation
    L_meg = jnp.load('L_meg.npy') * (u.fT / (u.nA * u.meter))
 
    # 2. Create neural mass model (Jansen-Rit for EEG)
-   nmm = brainmass.JansenRitModel(in_size=N_sources)
+   nmm = brainmass.JansenRitStep(in_size=N_sources)
    nmm.init_all_states()
 
    # 3. Create forward models

--- a/docs/api/models.rst
+++ b/docs/api/models.rst
@@ -159,7 +159,7 @@ to limit cycle oscillations as the bifurcation parameter crosses zero:
 
    hopf = brainmass.HopfStep(
        in_size=5,
-       omega=2 * jnp.pi * 10 * u.Hz,  # 10 Hz oscillation
+       w=0.1,  # intrinsic frequency (dimensionless)
        a=0.1,  # bifurcation parameter > 0 for oscillations
    )
    hopf.init_all_states()
@@ -276,9 +276,9 @@ Spiking Network Reductions
    MontbrioPazoRoxinStep
 
 
-**Example: QIF Model (Montbrio-Pazo-Roxin)**
+**Example: Montbrio-Pazo-Roxin Model (mean-field)**
 
-The QIF model is an exact mean-field reduction of networks of quadratic integrate-and-fire neurons:
+The Montbrio-Pazo-Roxin model is an exact mean-field reduction of networks of quadratic integrate-and-fire neurons:
 
 .. code-block:: python
 
@@ -305,7 +305,7 @@ All models support adding stochastic noise through dedicated noise attributes:
 .. code-block:: python
 
    # Create model
-   model = brainmass.HopfStep(in_size=10, omega=10 * u.Hz)
+   model = brainmass.HopfStep(in_size=10, w=0.2)
 
    # Add Ornstein-Uhlenbeck noise
    model.noise = brainmass.OUProcess(
@@ -333,7 +333,7 @@ To create multi-region brain networks, combine models with coupling mechanisms:
    N = 90  # number of regions
 
    # Create node dynamics
-   nodes = brainmass.HopfStep(in_size=N, omega=10 * u.Hz)
+   nodes = brainmass.HopfStep(in_size=N, w=0.3)
 
    # Create coupling
    coupling = brainmass.DiffusiveCoupling(

--- a/docs/api/noise.rst
+++ b/docs/api/noise.rst
@@ -71,7 +71,7 @@ The most common pattern is to attach noise directly to model attributes:
    import brainunit as u
 
    # Create model
-   model = brainmass.WilsonCowanModel(in_size=10)
+   model = brainmass.WilsonCowanStep(in_size=10)
 
    # Attach noise to specific populations
    model.noise_E = brainmass.OUProcess(
@@ -302,7 +302,7 @@ Common Patterns
 
 .. code-block:: python
 
-   model = brainmass.WilsonCowanModel(in_size=10)
+   model = brainmass.WilsonCowanStep(in_size=10)
 
    # Stronger noise for excitatory population
    model.noise_E = brainmass.OUProcess(in_size=10, sigma=0.8 * u.Hz, tau=20. * u.ms)
@@ -319,7 +319,7 @@ Common Patterns
    drive = brainmass.PinkNoise(in_size=1, sigma=0.5 * u.Hz)
    drive.init_all_states()
 
-   model = brainmass.HopfOscillator(in_size=1)
+   model = brainmass.HopfStep(in_size=1)
    model.init_all_states()
 
    # Apply as external input

--- a/docs/api/utilities.rst
+++ b/docs/api/utilities.rst
@@ -142,7 +142,7 @@ Processes a sequence through a model, handling state management automatically.
    import brainstate
 
    # Create model
-   model = brainmass.HopfOscillator(in_size=5, omega=10)
+   model = brainmass.HopfStep(in_size=5, w=0.2)
    model.init_all_states()
 
    # Input sequence

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ shutil.copy('../changelog.md', './changelog.md')
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
+    'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
@@ -144,7 +145,14 @@ html_last_updated_fmt = ""
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-jupyter_execute_notebooks = "off"
+
+# Notebooks under ``examples/`` are NOT executed at build time, on purpose: every notebook
+# already carries embedded outputs, several are large (``003-jansen-rit`` / ``008-horn`` ~2 MB),
+# and ``100-modeling_resting_state_MEG_data`` downloads HCP sample data via kagglehub on demand.
+# Documentation is kept honest instead by ``sphinx.ext.doctest`` (docstring ``>>>`` examples plus
+# tutorial ``.. testcode::`` blocks); goal-03 wires these checks into CI.
+nb_execution_mode = "off"          # myst-nb >= 0.13 (current)
+jupyter_execute_notebooks = "off"  # legacy alias, kept for older myst-nb
 thebe_config = {
     "repository_url": "https://github.com/binder-examples/jupyter-stacks-datascience",
     "repository_branch": "master",
@@ -154,8 +162,23 @@ html_theme_options = {
     'show_toc_level': 2,
 }
 
-# -- Options for myst ----------------------------------------------
+# -- Options for doctest (sphinx.ext.doctest) ----------------------
+#
+# ``make doctest`` (and goal-03's CI job) executes every docstring ``>>>`` example and every
+# ``.. testcode::`` block in the tutorials, so documented code cannot drift from the API again.
+# The setup below is prepended to each doctest group, giving examples the common imports and a
+# default integration step without per-example boilerplate. Examples needing a different ``dt``
+# (e.g. the dimensionless ``BOLDSignal``) reset it locally.
+doctest_global_setup = """
+import brainmass
+import brainstate
+import brainunit as u
+import jax
+import jax.numpy as jnp
+import numpy as np
+brainstate.environ.set(dt=0.1 * u.ms)
+"""
 
-autodoc_default_options = {
-    'exclude-members': '....,default_rng',
-}
+# Test bare ``>>>`` doctest blocks (the NumPy-doc ``Examples`` sections) in addition to the
+# explicit ``.. testcode::`` / ``.. doctest::`` directives.
+doctest_test_doctest_blocks = "default"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,6 +170,8 @@ html_theme_options = {
 # default integration step without per-example boilerplate. Examples needing a different ``dt``
 # (e.g. the dimensionless ``BOLDSignal``) reset it locally.
 doctest_global_setup = """
+import matplotlib
+matplotlib.use("Agg")  # headless: example ``plt.show()`` calls must not block the build
 import brainmass
 import brainstate
 import brainunit as u

--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -18,7 +18,7 @@ Package Structure
    ├── _wong_wang.py        # Wong-Wang model
    ├── _vdp.py              # Van der Pol oscillator
    ├── _sl.py               # Stuart-Landau oscillator
-   ├── _qif.py              # QIF model
+   ├── qif.py               # Montbrio-Pazo-Roxin (mean-field) model
    ├── _linear.py           # Threshold-linear model
    ├── _kuramoto.py         # Kuramoto network
    ├── _xy_model.py         # XY oscillator base class

--- a/docs/developer/contributing.rst
+++ b/docs/developer/contributing.rst
@@ -128,7 +128,7 @@ Good examples:
 
 .. code-block:: text
 
-   Add QIF model implementation
+   Add Montbrio-Pazo-Roxin model implementation
 
    Fix coupling bug in DiffusiveCoupling
 

--- a/docs/developer/contributing.rst
+++ b/docs/developer/contributing.rst
@@ -25,11 +25,17 @@ Development Setup
       git clone https://github.com/YOUR_USERNAME/brainmass.git
       cd brainmass
 
-3. Install in development mode:
+3. Install in development mode with the test and documentation dependencies:
 
    .. code-block:: bash
 
-      pip install -e .[dev,doc]
+      pip install -e .
+      pip install -r requirements-doc.txt
+
+   ``requirements-doc.txt`` includes ``requirements-dev.txt`` (which in turn includes the
+   runtime ``requirements.txt``), so this single command pulls in the runtime, test, and
+   documentation dependencies. (Consolidated ``[dev,doc]`` install extras are planned -- see
+   the roadmap.)
 
 4. Create a branch:
 
@@ -51,15 +57,17 @@ Code Guidelines
 **Documentation:**
 
 - Add docstrings to all public functions/classes
-- Use Google-style docstrings
-- Include examples in docstrings
+- Use NumPy-style docstrings (match the existing modules; see :doc:`documentation`)
+- Include runnable examples in docstrings
 - Update relevant tutorial/API docs
 
 **Testing:**
 
+- Tests are co-located with the source as ``brainmass/<module>_test.py`` (there is no
+  separate top-level ``tests/`` directory)
 - Write tests for new features
 - Ensure existing tests pass
-- Aim for >80% code coverage
+- Aim for >90% code coverage
 
 
 Pull Request Process
@@ -67,10 +75,10 @@ Pull Request Process
 
 1. **Before submitting:**
 
-   - Run tests: ``pytest tests/``
+   - Run tests: ``pytest brainmass/``
    - Check code style: ``ruff check brainmass/``
    - Build docs: ``make -C docs html``
-   - Update CHANGELOG
+   - Update ``changelog.md``
 
 2. **PR description:**
 
@@ -88,17 +96,20 @@ Pull Request Process
 Testing
 -------
 
+Tests live next to the code they exercise, named ``brainmass/<module>_test.py``.
+
 Run all tests:
 
 .. code-block:: bash
 
-   pytest tests/
+   pytest brainmass/
 
-Run specific test:
+Run the tests for a single module, or a single test class/method:
 
 .. code-block:: bash
 
-   pytest tests/test_models.py::test_hopf_oscillator
+   pytest brainmass/hopf_test.py
+   pytest brainmass/hopf_test.py::TestHopfModel
 
 
 Documentation
@@ -173,8 +184,8 @@ Release Process
 
 (For maintainers)
 
-1. Update version in ``pyproject.toml``
-2. Update ``CHANGELOG.md``
+1. Update the version in ``brainmass/_version.py`` (``pyproject.toml`` reads it dynamically)
+2. Update ``changelog.md``
 3. Create release tag
 4. Build and publish to PyPI
 

--- a/docs/developer/documentation.rst
+++ b/docs/developer/documentation.rst
@@ -128,7 +128,7 @@ Example Tutorial Template
 
       # Code example
       import brainmass
-      model = brainmass.HopfOscillator(in_size=10)
+      model = brainmass.HopfStep(in_size=10)
 
    [More steps...]
 

--- a/docs/developer/testing.rst
+++ b/docs/developer/testing.rst
@@ -53,7 +53,7 @@ Basic Test
 
    def test_hopf_oscillator():
        # Create model
-       model = brainmass.HopfOscillator(in_size=10, omega=10)
+       model = brainmass.HopfStep(in_size=10, w=0.2)
 
        # Initialize
        model.init_all_states()
@@ -73,7 +73,7 @@ Parametrized Tests
 
    @pytest.mark.parametrize("in_size", [1, 10, 100])
    def test_model_shapes(in_size):
-       model = brainmass.WilsonCowanModel(in_size=in_size)
+       model = brainmass.WilsonCowanStep(in_size=in_size)
        model.init_all_states()
 
        output = model.update(rE_inp=0.5, rI_inp=0.2)
@@ -87,7 +87,7 @@ Batch Testing
 
    @pytest.mark.parametrize("batch_size", [None, 1, 32])
    def test_batching(batch_size):
-       model = brainmass.HopfOscillator(in_size=5, omega=10)
+       model = brainmass.HopfStep(in_size=5, w=0.2)
        model.init_all_states(batch_size=batch_size)
 
        output = model.update()

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -39,7 +39,7 @@ Usage Questions
 
 **Q: Which model should I use for fMRI?**
 
-A: Use :class:`WongWangModel` or :class:`WilsonCowanModel`. They have slow synaptic dynamics suitable for BOLD timescales. See :doc:`tutorials/choosing_models`.
+A: Use :class:`WongWangStep` or :class:`WilsonCowanStep`. They have slow synaptic dynamics suitable for BOLD timescales. See :doc:`tutorials/choosing_models`.
 
 
 **Q: How do I fit parameters to my data?**
@@ -217,7 +217,7 @@ Fix: Call ``model.init_all_states()`` before ``model.update()``
 
 .. code-block:: python
 
-   model = brainmass.HopfOscillator(in_size=10)
+   model = brainmass.HopfStep(in_size=10)
    model.init_all_states()  # Required!
    model.update()
 
@@ -229,7 +229,7 @@ Fix: Ensure connectivity matrix matches node dimensions:
 .. code-block:: python
 
    N = 90
-   nodes = brainmass.HopfOscillator(in_size=N)
+   nodes = brainmass.HopfStep(in_size=N)
    W = jnp.ones((N, N))  # Must be (N, N)
 
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,7 +20,7 @@ though the suggested sequencing (see *Dependencies* at the end) builds the safet
 | **A** | Fitting & orchestration layer | functionality + usability | Large | In design |
 | **B** | Testing rigor | testing | Medium | Planned |
 | **C** | CI / tooling & release hygiene | maintainability | Small–Medium | Planned |
-| **D** | Documentation integrity | documentation | Small–Medium | Planned |
+| **D** | Documentation integrity | documentation | Small–Medium | Done (goal-02) |
 | **E** | Code correctness & structure | maintainability | Medium | Planned |
 
 ### What tvboptim does that we can learn from
@@ -157,28 +157,30 @@ fail on a real release, and the declared minimum Python is never tested.
 
 ## D. Documentation integrity
 
-**Dimension:** documentation · **Effort:** Small–Medium · **Status:** Planned
+**Dimension:** documentation · **Effort:** Small–Medium · **Status:** Done (goal-02);
+CI gating deferred to sub-project C (goal-03)
 
-After the `*Step` rename, the prose and tutorials reference symbols that no longer
-exist — the Quickstart example does not even import — and nothing catches it because
-notebooks/tutorials are not executed at build time.
+After the `*Step` rename, the prose and tutorials referenced symbols that no longer
+existed — the Quickstart example did not even import — and nothing caught it because
+notebooks/tutorials are not executed at build time. Addressed by goal-02.
 
-- [ ] **Fix the pervasive API drift.** Replace renamed symbols across prose/tutorials:
-      `HopfOscillator` (×26, incl. the headline Quickstart), `WilsonCowanModel` (×18),
-      `WongWangModel`, `FitzHughNagumoModel`, `StuartLandauOscillator`,
-      `VanDerPolOscillator`, and `QIF` (→ `MontbrioPazoRoxinStep`).
-- [ ] **Execute docs in CI.** `jupyter_execute_notebooks` is `"off"`; turn on
-      notebook/tutorial execution and/or add a doctest + notebook-smoke CI job so drift
-      can't recur (mirror tvboptim's "docs cells execute in CI").
-- [ ] **Fix `docs/conf.py`** — `autodoc_default_options` is defined twice (≈ lines 100
-      and 159); the second silently disables `members` / `special-members` /
-      `undoc-members`. Merge into one.
-- [ ] Add a **usage code snippet to `README.md`** (currently none); fix the stale
-      citation version (`0.0.4` → current).
-- [ ] Add the **missing `0.0.6` changelog entry**.
-- [ ] **Fix `developer/contributing.rst` contradictions** — it says "use Google-style
-      docstrings" (project standard is NumPy-doc) and references the nonexistent `tests/`
-      dir and `[dev,doc]` extras.
+- [x] **Fixed the pervasive API drift.** Replaced the legacy ``*Oscillator`` / ``*Model``
+      class aliases (Hopf, Wilson–Cowan, Wong–Wang, FitzHugh–Nagumo, Stuart–Landau, Van der
+      Pol, and the Montbrió–Pazó–Roxin mean-field model) with their canonical ``*Step`` names
+      across prose and tutorials; grep-verified that none remain (goal-02).
+- [x] **Made docs self-checking (content + config).** Enabled `sphinx.ext.doctest`: every
+      docstring `>>>` example is doctest-clean and the Quickstart / units guide run as
+      executable `.. testcode::` blocks. Notebooks stay non-executed (large embedded outputs;
+      HCP data dependency) and are documented as such. *Wiring `make doctest` into CI is
+      sub-project C (goal-03).*
+- [x] **Fixed `docs/conf.py`** — merged the duplicated `autodoc_default_options` (the second
+      silently disabled `members` / `special-members` / `undoc-members`) into one (goal-02).
+- [x] Added a **usage code snippet to `README.md`** and fixed the stale citation version
+      (`0.0.4` → `0.0.6`) (goal-02).
+- [x] Added the **`0.0.6` changelog entry** (goal-02).
+- [x] **Fixed `developer/contributing.rst` contradictions** — NumPy-doc (not Google-style),
+      co-located `*_test.py` (not a `tests/` dir), and the dev/doc install instructions
+      (goal-02).
 - [ ] Evaluate the **one-source → tested-HTML + clean-Colab** tutorial pipeline from
       tvboptim.
 

--- a/docs/tutorials/adding_coupling.rst
+++ b/docs/tutorials/adding_coupling.rst
@@ -5,6 +5,14 @@ This tutorial focuses on coupling mechanisms for connecting brain regions in net
 
 See :doc:`building_networks` for general network setup. This guide covers coupling details.
 
+.. note::
+
+   The first **Diffusive Coupling** example below is executed as part of the documentation
+   build and shows the real construction API. The later snippets are *conceptual*: they use a
+   shorthand ``coupling(source, target)`` form to focus on the mathematics of each coupling
+   type and are not executed. In real code a coupling is always constructed from *prefetch*
+   references to a node module's state, as in the first example and in :doc:`quickstart`.
+
 
 Coupling Types
 --------------
@@ -18,19 +26,40 @@ Drives nodes toward their neighbors' states:
 
    C_i = k \sum_j W_{ij} (x_j - x_i)
 
-.. code-block:: python
+A ``DiffusiveCoupling`` is built from two prefetch reads of the node state: a (possibly
+delayed) read of every *source* node and a read of each *target* (self) node. It returns a
+per-node coupling current:
+
+.. testcode::
 
    import brainmass
+   import braintools
+   import brainstate
+   import brainunit as u
    import jax.numpy as jnp
+   import numpy as np
 
-   W = jnp.ones((10, 10)) * 0.1  # connectivity matrix
-   W = W.at[jnp.diag_indices(10)].set(0.)
+   brainstate.environ.set(dt=0.1 * u.ms)
+   N = 10
 
-   coupling = brainmass.DiffusiveCoupling(conn=W, k=0.5)
-   coupling.init_all_states()
+   nodes = brainmass.HopfStep(in_size=N, a=0.25, w=0.2)
 
-   # Use in network
-   coupled_input = coupling(source_activity, target_activity)
+   W = jnp.ones((N, N)) * 0.1  # connectivity matrix
+   W = W.at[jnp.diag_indices(N)].set(0.)  # no self-connections
+
+   # Each target reads every source's (delayed) ``x`` -> shape (N, N)
+   delays = jnp.ones((N, N)) * (1.0 * u.ms)
+   src_idx = np.tile(np.arange(N)[None, :], (N, 1))
+   x_src = nodes.prefetch_delay('x', delays, src_idx, init=braintools.init.ZeroInit())
+   x_self = nodes.prefetch('x')
+
+   coupling = brainmass.DiffusiveCoupling(x_src, x_self, conn=W, k=0.5)
+
+   brainstate.nn.init_all_states(nodes)
+   brainstate.nn.init_all_states(coupling)
+
+   with brainstate.environ.context(i=0, t=0. * u.ms):
+       coupled_input = coupling.update()  # (N,) per-node coupling current
 
 
 Additive Coupling

--- a/docs/tutorials/building_networks.rst
+++ b/docs/tutorials/building_networks.rst
@@ -3,6 +3,15 @@ Building Multi-Region Networks
 
 This tutorial covers creating and simulating large-scale brain networks with multiple regions.
 
+.. note::
+
+   Except for the first **Simple Network Example** (which is executed as part of the
+   documentation build), the snippets on this page are *schematic*: they illustrate
+   the structure of a whole-brain workflow and depend on external data files
+   (e.g. ``jnp.load('AAL90_SC.npy')``) or omit boilerplate wiring, so they are not
+   run during the build. For a complete, copy-pasteable coupling example see
+   :doc:`quickstart`.
+
 
 Basic Network Setup
 -------------------
@@ -16,46 +25,54 @@ A brain network consists of:
 Simple Network Example
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-.. code-block:: python
+``DiffusiveCoupling`` reads each node's state through a *prefetch* (here a delayed
+read of ``x``), multiplies the pairwise differences by the connectivity, and returns
+a per-node current you feed back into ``update``:
+
+.. testcode::
 
    import brainmass
+   import braintools
    import jax.numpy as jnp
+   import numpy as np
    import brainunit as u
    import brainstate
 
+   brainstate.environ.set(dt=0.1 * u.ms)
    N_regions = 10
 
-   # 1. Create node dynamics (uncoupled)
+   # 1. Create node dynamics
    nodes = brainmass.HopfStep(
        in_size=N_regions,
-       omega=2 * jnp.pi * 10 * u.Hz,
+       w=0.2,   # intrinsic angular frequency (dimensionless normal-form parameter)
        a=0.1,
    )
 
-   # 2. Create structural connectivity
+   # 2. Create structural connectivity (no self-connections)
    W = jnp.ones((N_regions, N_regions)) * 0.05
-   W = W.at[jnp.diag_indices(N_regions)].set(0.)  # no self-connections
+   W = W.at[jnp.diag_indices(N_regions)].set(0.)
 
-   # 3. Create coupling
-   coupling = brainmass.DiffusiveCoupling(conn=W, k=0.2)
+   # 3. Wire coupling: every target reads each source's delayed ``x``
+   delays = jnp.ones((N_regions, N_regions)) * (1.0 * u.ms)
+   src_idx = np.tile(np.arange(N_regions)[None, :], (N_regions, 1))
+   x_delayed = nodes.prefetch_delay('x', delays, src_idx, init=braintools.init.ZeroInit())
+   x_local = nodes.prefetch('x')
+   coupling = brainmass.DiffusiveCoupling(x_delayed, x_local, conn=W, k=0.2)
 
-   # 4. Initialize
-   nodes.init_all_states()
-   coupling.init_all_states()
+   # 4. Initialize (the coupling owns the delay buffer)
+   brainstate.nn.init_all_states(nodes)
+   brainstate.nn.init_all_states(coupling)
 
    # 5. Simulation loop
    def network_step(i):
-       x = nodes.x.value
-       coupled_input = coupling(x, x)
-
-       output = nodes.update()
-       nodes.x.value += coupled_input
-
-       return output
+       with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+           coupled_input = coupling.update()   # (N,) coupling current
+           nodes.update(coupled_input, 0.0)    # feed it as the x input
+           return nodes.x.value
 
    network_activity = brainstate.transform.for_loop(
        network_step,
-       jnp.arange(1000)
+       np.arange(1000),
    )
 
 
@@ -202,7 +219,7 @@ Different Models per Region
    N_thal = 10
    thalamus = brainmass.HopfStep(
        in_size=N_thal,
-       omega=2 * jnp.pi * 40 * u.Hz,  # 40 Hz
+       w=0.3,  # faster intrinsic frequency than the cortical subsystem
    )
 
    # Cortex: excitatory-inhibitory dynamics

--- a/docs/tutorials/building_networks.rst
+++ b/docs/tutorials/building_networks.rst
@@ -26,7 +26,7 @@ Simple Network Example
    N_regions = 10
 
    # 1. Create node dynamics (uncoupled)
-   nodes = brainmass.HopfOscillator(
+   nodes = brainmass.HopfStep(
        in_size=N_regions,
        omega=2 * jnp.pi * 10 * u.Hz,
        a=0.1,
@@ -152,7 +152,7 @@ Using Anatomical Atlases
    SC_AAL90 = jnp.load('AAL90_SC.npy')  # from DTI
 
    # Create network
-   nodes = brainmass.WilsonCowanModel(in_size=N_AAL90)
+   nodes = brainmass.WilsonCowanStep(in_size=N_AAL90)
    coupling = brainmass.DiffusiveCoupling(conn=SC_AAL90, k=0.1)
 
 
@@ -200,14 +200,14 @@ Different Models per Region
 
    # Thalamus: fast oscillators
    N_thal = 10
-   thalamus = brainmass.HopfOscillator(
+   thalamus = brainmass.HopfStep(
        in_size=N_thal,
        omega=2 * jnp.pi * 40 * u.Hz,  # 40 Hz
    )
 
    # Cortex: excitatory-inhibitory dynamics
    N_cort = 80
-   cortex = brainmass.WilsonCowanModel(in_size=N_cort)
+   cortex = brainmass.WilsonCowanStep(in_size=N_cort)
 
    # Coupling between subsystems
    W_thal_cort = jnp.ones((N_cort, N_thal)) * 0.1  # thalamus → cortex
@@ -312,7 +312,7 @@ Whole-Brain Resting-State Simulation
    SC = jnp.load('AAL90_SC_normalized.npy')
 
    # Create components
-   nodes = brainmass.WongWangModel(in_size=N_regions)
+   nodes = brainmass.WongWangStep(in_size=N_regions)
    coupling = brainmass.DiffusiveCoupling(conn=SC, k=coupling_strength)
 
    # Add noise for spontaneous activity

--- a/docs/tutorials/choosing_models.rst
+++ b/docs/tutorials/choosing_models.rst
@@ -11,16 +11,16 @@ Decision Tree
 
    Need physiological realism?
    ├─ YES → Physiological Models
-   │  ├─ Modeling EEG/MEG? → JansenRitModel
-   │  ├─ Modeling fMRI BOLD? → WongWangModel
-   │  ├─ E-I population dynamics? → WilsonCowanModel
-   │  └─ Mean-field spiking? → QIFModel (MontbrioPazoRoxin)
+   │  ├─ Modeling EEG/MEG? → JansenRitStep
+   │  ├─ Modeling fMRI BOLD? → WongWangStep
+   │  ├─ E-I population dynamics? → WilsonCowanStep
+   │  └─ Mean-field spiking? → MontbrioPazoRoxinStep
    │
    └─ NO → Phenomenological Models
-      ├─ Studying oscillations? → HopfOscillator or StuartLandauOscillator
-      ├─ Studying excitability? → FitzHughNagumoModel
+      ├─ Studying oscillations? → HopfStep or StuartLandauStep
+      ├─ Studying excitability? → FitzHughNagumoStep
       ├─ Phase synchronization? → KuramotoNetwork
-      └─ Fast/simple dynamics? → ThresholdLinearModel
+      └─ Fast/simple dynamics? → ThresholdLinearStep
 
 
 Model Categories
@@ -44,9 +44,9 @@ Phenomenological Models
 
 .. code-block:: python
 
-   hopf = brainmass.HopfOscillator(
+   hopf = brainmass.HopfStep(
        in_size=90,
-       omega=2 * jnp.pi * 10 * u.Hz,  # 10 Hz alpha rhythm
+       w=0.1,  # intrinsic frequency (dimensionless)
        a=0.1,  # >0 for limit cycle
    )
 
@@ -83,7 +83,7 @@ Physiological Models
 
 .. code-block:: python
 
-   jr = brainmass.JansenRitModel(
+   jr = brainmass.JansenRitStep(
        in_size=68,  # number of cortical sources
    )
 
@@ -101,10 +101,10 @@ Physiological Models
 - **Variables:** 2 (S_E, S_I)
 - **Example use:** Whole-brain resting-state fMRI simulations
 
-**QIF Model (Montbrio-Pazo-Roxin)**
+**Montbrio-Pazo-Roxin Model**
 
 - **Best for:** Mean-field reduction of spiking networks
-- **Key feature:** Exact reduction of QIF neuron networks
+- **Key feature:** Exact mean-field reduction of quadratic integrate-and-fire neuron networks
 - **Variables:** 2 (r, v)
 - **Example use:** Linking spiking and rate dynamics
 
@@ -156,7 +156,7 @@ Model Comparison
      - Slow
      - High
      - fMRI BOLD, decision making
-   * - QIF
+   * - Montbrio-Pazo-Roxin
      - Medium
      - Medium
      - High
@@ -171,7 +171,7 @@ Resting-State fMRI Study
 
 **Goal:** Simulate spontaneous BOLD fluctuations matching empirical FC
 
-**Recommended:** :class:`WongWangModel` or :class:`WilsonCowanModel`
+**Recommended:** :class:`WongWangStep` or :class:`WilsonCowanStep`
 
 **Why:**
 - Slow synaptic dynamics (NMDA) match BOLD timescales
@@ -180,11 +180,11 @@ Resting-State fMRI Study
 
 .. code-block:: python
 
-   nodes = brainmass.WongWangModel(in_size=90)  # AAL90 atlas
+   nodes = brainmass.WongWangStep(in_size=90)  # AAL90 atlas
    bold = brainmass.BOLDSignal(in_size=90)
 
    # Add structural coupling from DTI
-   coupling = brainmass.DiffusiveCoupling(conn=SC_matrix, k=0.2)
+   # add structural coupling from a DTI connectome (see the adding_coupling tutorial)
 
 
 EEG Source Modeling
@@ -192,7 +192,7 @@ EEG Source Modeling
 
 **Goal:** Simulate EEG signals from cortical sources
 
-**Recommended:** :class:`JansenRitModel`
+**Recommended:** :class:`JansenRitStep`
 
 **Why:**
 
@@ -202,7 +202,7 @@ EEG Source Modeling
 
 .. code-block:: python
 
-   jr = brainmass.JansenRitModel(in_size=68)  # cortical parcels
+   jr = brainmass.JansenRitStep(in_size=68)  # cortical parcels
    eeg_fwd = brainmass.EEGLeadFieldModel(
        in_size=68,
        out_size=64,  # electrodes
@@ -215,7 +215,7 @@ Synchronization Study
 
 **Goal:** Study emergence of network synchronization
 
-**Recommended:** :class:`HopfOscillator` or :class:`KuramotoNetwork`
+**Recommended:** :class:`HopfStep` or :class:`KuramotoNetwork`
 
 **Why:**
 
@@ -233,7 +233,7 @@ Synchronization Study
    )
 
    # Hopf for amplitude + phase
-   hopf = brainmass.HopfOscillator(in_size=100, omega=10 * u.Hz, a=0.1)
+   hopf = brainmass.HopfStep(in_size=100, w=0.2, a=0.1)
 
 
 Parameter Fitting Study
@@ -245,9 +245,9 @@ Parameter Fitting Study
 
 **Strategy:**
 
-1. Start with :class:`HopfOscillator` or :class:`WilsonCowanModel` (fewer parameters)
+1. Start with :class:`HopfStep` or :class:`WilsonCowanStep` (fewer parameters)
 2. Validate parameter estimates
-3. If needed, move to :class:`JansenRitModel` or :class:`WongWangModel`
+3. If needed, move to :class:`JansenRitStep` or :class:`WongWangStep`
 
 **Why:**
 
@@ -290,15 +290,16 @@ You can use different models for different regions:
 .. code-block:: python
 
    # Thalamus: fast dynamics
-   thalamus = brainmass.HopfOscillator(in_size=N_thal, omega=40 * u.Hz)
+   thalamus = brainmass.HopfStep(in_size=N_thal, w=0.3)
 
    # Cortex: slower dynamics
-   cortex = brainmass.WilsonCowanModel(in_size=N_cort)
+   cortex = brainmass.WilsonCowanStep(in_size=N_cort)
 
    # Couple them
    def network_step(i):
-       thal_out = thalamus.update()
-       cort_out = cortex.update(rE_inp=thal_out.mean())  # thalamic drive
+       thalamus.update()  # advance the thalamus
+       thal_drive = thalamus.x.value.mean()  # use thalamic x as drive
+       cort_out = cortex.update(rE_inp=thal_drive)
        return cort_out
 
 
@@ -325,19 +326,19 @@ Summary Recommendations
    * - Your Goal
      - Recommended Model
    * - Learn brainmass basics
-     - :class:`HopfOscillator` or :class:`WilsonCowanModel`
+     - :class:`HopfStep` or :class:`WilsonCowanStep`
    * - EEG/MEG modeling
-     - :class:`JansenRitModel`
+     - :class:`JansenRitStep`
    * - fMRI BOLD modeling
-     - :class:`WongWangModel` or :class:`WilsonCowanModel`
+     - :class:`WongWangStep` or :class:`WilsonCowanStep`
    * - Fast exploratory work
-     - :class:`Hopf Oscillator` or :class:`ThresholdLinearModel`
+     - :class:`Hopf Oscillator` or :class:`ThresholdLinearStep`
    * - Excitable dynamics
-     - :class:`FitzHughNagumoModel`
+     - :class:`FitzHughNagumoStep`
    * - Spiking network reduction
-     - :class:`QIFModel`
+     - :class:`MontbrioPazoRoxinStep`
    * - Synchronization studies
-     - :class:`KuramotoNetwork` or :class:`HopfOscillator`
+     - :class:`KuramotoNetwork` or :class:`HopfStep`
 
 
 Next Steps

--- a/docs/tutorials/forward_modeling.rst
+++ b/docs/tutorials/forward_modeling.rst
@@ -36,7 +36,7 @@ Basic BOLD Workflow
    N_regions = 90
 
    # 1. Create neural mass model
-   nmm = brainmass.WongWangModel(in_size=N_regions)
+   nmm = brainmass.WongWangStep(in_size=N_regions)
    nmm.init_all_states()
 
    # 2. Create BOLD hemodynamic model
@@ -84,7 +84,7 @@ Complete fMRI Simulation
    SC = jnp.load('SC_AAL90.npy')
 
    # Create network
-   nodes = brainmass.WongWangModel(in_size=N)
+   nodes = brainmass.WongWangStep(in_size=N)
    coupling = brainmass.DiffusiveCoupling(conn=SC, k=0.2)
    nodes.noise_E = brainmass.OUProcess(in_size=N, sigma=0.01*u.Hz, tau=100*u.ms)
 
@@ -166,7 +166,7 @@ EEG Simulation
    import brainstate
 
    # Jansen-Rit model (generates EEG-like signals)
-   nmm = brainmass.JansenRitModel(in_size=N_sources)
+   nmm = brainmass.JansenRitStep(in_size=N_sources)
    nmm.init_all_states()
 
    # Simulate source activity
@@ -212,7 +212,7 @@ Simultaneous EEG/MEG/fMRI
 .. code-block:: python
 
    # Use same neural activity for all modalities
-   nmm = brainmass.JansenRitModel(in_size=68)
+   nmm = brainmass.JansenRitStep(in_size=68)
    nmm.init_all_states()
 
    # Forward models

--- a/docs/tutorials/forward_modeling.rst
+++ b/docs/tutorials/forward_modeling.rst
@@ -3,6 +3,14 @@ Forward Modeling
 
 Forward models map neural activity to observable neuroimaging signals (BOLD, EEG, MEG).
 
+.. note::
+
+   The snippets on this page are *schematic*: they sketch the forward-modeling workflow and
+   in places assume empirical data or a network driver, so they are not executed in the
+   documentation build. For runnable, current-API forward-model code see the
+   Balloon-Windkessel BOLD section of :doc:`quickstart` and the ``LeadFieldModel`` examples in
+   :doc:`../api/forward`.
+
 
 Overview
 --------

--- a/docs/tutorials/installation.rst
+++ b/docs/tutorials/installation.rst
@@ -126,7 +126,7 @@ After installation, verify that everything works:
    print(f"brainmass version: {brainmass.__version__}")
 
    # Test basic functionality
-   model = brainmass.HopfOscillator(in_size=10, omega=10 * u.Hz)
+   model = brainmass.HopfStep(in_size=10, w=0.2)
    model.init_all_states()
    output = model.update()
 

--- a/docs/tutorials/parameter_fitting.rst
+++ b/docs/tutorials/parameter_fitting.rst
@@ -3,6 +3,13 @@ Parameter Fitting
 
 This tutorial covers optimizing model parameters to match empirical data.
 
+.. note::
+
+   The snippets on this page are *schematic*: parameter fitting requires empirical data and a
+   full simulation driver, so the optimization examples below are illustrative and not executed
+   in the documentation build. For the runnable simulation building blocks they rely on (model
+   construction, stepping, coupling, BOLD) see :doc:`quickstart` and :doc:`building_networks`.
+
 
 Overview
 --------

--- a/docs/tutorials/parameter_fitting.rst
+++ b/docs/tutorials/parameter_fitting.rst
@@ -111,7 +111,7 @@ Best for non-differentiable objectives:
 
    # Define simulation function
    def simulate_network(coupling_strength):
-       nodes = brainmass.WongWangModel(in_size=90)
+       nodes = brainmass.WongWangStep(in_size=90)
        coupling = brainmass.DiffusiveCoupling(conn=SC, k=coupling_strength)
        bold = brainmass.BOLDSignal(in_size=90)
 
@@ -377,7 +377,7 @@ Full FC-Based Parameter Fitting
        T = 600000  # 10 min at 1ms
 
        # Create network
-       nodes = brainmass.WongWangModel(in_size=N)
+       nodes = brainmass.WongWangStep(in_size=N)
        coupling = brainmass.DiffusiveCoupling(conn=SC, k=coupling_k)
        nodes.noise_E = brainmass.OUProcess(
            in_size=N,

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -4,39 +4,51 @@ Quickstart
 This 5-minute tutorial demonstrates the basic ``brainmass`` workflow: create a neural mass model,
 add noise, simulate dynamics, and visualize results.
 
+.. note::
+
+   Every code block on this page is executed as part of the documentation build
+   (via ``sphinx.ext.doctest``), so the snippets are guaranteed to run against the
+   current API. The integration time step ``dt`` is a global set through
+   ``brainstate.environ`` -- it is **not** a model argument.
+
 
 Your First Simulation
 ----------------------
 
 Let's simulate a single brain region using the Hopf oscillator model:
 
-.. code-block:: python
+.. testcode::
 
    import brainmass
-   import brainunit as u
    import brainstate
-   import jax.numpy as jnp
+   import brainunit as u
+   import numpy as np
    import matplotlib.pyplot as plt
 
-   # 1. Create a Hopf oscillator (10 Hz oscillation)
-   model = brainmass.HopfOscillator(
-       in_size=1,              # single region
-       omega=2 * jnp.pi * 10 * u.Hz,  # 10 Hz frequency
-       a=0.1,                  # bifurcation parameter (>0 for oscillations)
+   # dt is global state, set once through the environment
+   brainstate.environ.set(dt=0.1 * u.ms)
+
+   # 1. Create a Hopf oscillator in the limit-cycle regime
+   model = brainmass.HopfStep(
+       in_size=1,   # single region
+       a=0.25,      # bifurcation parameter (>0 -> self-sustained oscillation)
+       w=0.2,       # intrinsic angular frequency (dimensionless)
    )
 
-   # 2. Initialize model state
+   # 2. Initialize the model state
    model.init_all_states()
 
-   # 3. Run simulation for 1000 time steps
+   # 3. Run the simulation for 1000 time steps, recording x each step
    def step(i):
-       return model.update()
+       with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+           model.update()
+           return model.x.value
 
-   time_series = brainstate.transform.for_loop(step, jnp.arange(1000))
+   time_series = brainstate.transform.for_loop(step, np.arange(1000))
 
-   # 4. Visualize
+   # 4. Visualize (time_series has shape (1000, 1))
    plt.figure(figsize=(10, 4))
-   plt.plot(time_series[:, 0])  # plot x coordinate
+   plt.plot(time_series[:, 0])  # plot the x coordinate
    plt.xlabel('Time step')
    plt.ylabel('Activity')
    plt.title('Hopf Oscillator Dynamics')
@@ -45,181 +57,172 @@ Let's simulate a single brain region using the Hopf oscillator model:
 
 **What's happening:**
 
-- We create a 10 Hz oscillator (``omega = 2π × 10``)
-- ``a > 0`` puts the oscillator in the limit cycle regime
+- ``a > 0`` puts the oscillator in the limit-cycle (self-sustained oscillation) regime
+- ``w`` is the intrinsic angular frequency (dimensionless in this normal-form model)
+- ``brainstate.environ.context(i=, t=)`` supplies the step index/time the update needs
 - ``for_loop`` efficiently runs 1000 simulation steps
-- The output is a (1000, 1) array of the oscillator's x-coordinate
+- the output is a ``(1000, 1)`` array of the oscillator's x-coordinate
 
 
 Adding Noise
 ------------
 
-Real neural activity is noisy. Let's add stochastic fluctuations:
+Real neural activity is noisy. Attach Ornstein-Uhlenbeck noise processes when you
+construct the model. The XY-family oscillators expect a noise process for *both*
+components, and -- because the Hopf state is dimensionless -- ``sigma`` is dimensionless too:
 
-.. code-block:: python
+.. testcode::
 
    import brainmass
-   import brainunit as u
    import brainstate
-   import jax.numpy as jnp
+   import brainunit as u
+   import numpy as np
 
-   # Create oscillator
-   model = brainmass.HopfOscillator(in_size=1, omega=2 * jnp.pi * 10 * u.Hz, a=0.1)
+   brainstate.environ.set(dt=0.1 * u.ms)
 
-   # Add Ornstein-Uhlenbeck noise
-   model.noise = brainmass.OUProcess(
-       in_size=1,
-       sigma=0.5 * u.Hz,  # noise amplitude
-       tau=20. * u.ms,    # correlation time
+   model = brainmass.HopfStep(
+       in_size=1, a=0.25, w=0.2,
+       noise_x=brainmass.OUProcess(in_size=1, sigma=0.05, tau=20. * u.ms),
+       noise_y=brainmass.OUProcess(in_size=1, sigma=0.05, tau=20. * u.ms),
    )
 
-   # Initialize
-   model.init_all_states()
+   # init_all_states also initializes the attached noise sub-modules
+   brainstate.nn.init_all_states(model)
 
-   # Simulate with noise
-   time_series = brainstate.transform.for_loop(
-       lambda i: model.update(),
-       jnp.arange(1000)
-   )
+   def step(i):
+       with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+           model.update()
+           return model.x.value
+
+   time_series = brainstate.transform.for_loop(step, np.arange(1000))
 
 
-The noise is automatically added during ``update()``, creating more realistic fluctuations.
+The noise is added automatically inside ``update()``, creating more realistic fluctuations.
 
 
 Multi-Region Networks
-----------------------
+---------------------
 
-Simulate multiple brain regions simultaneously:
+Simulate multiple brain regions simultaneously by setting ``in_size`` to the number
+of regions. Here the regions are independent (no coupling yet):
 
-.. code-block:: python
+.. testcode::
 
    import brainmass
-   import jax.numpy as jnp
-   import brainunit as u
    import brainstate
+   import brainunit as u
+   import numpy as np
 
+   brainstate.environ.set(dt=0.1 * u.ms)
    N_regions = 10
 
-   # Create network of Wilson-Cowan models
-   network = brainmass.WilsonCowanModel(
+   # A bank of Wilson-Cowan models with per-population noise
+   network = brainmass.WilsonCowanStep(
        in_size=N_regions,
        tau_E=10. * u.ms,
        tau_I=20. * u.ms,
+       noise_E=brainmass.OUProcess(in_size=N_regions, sigma=0.1, tau=20. * u.ms),
+       noise_I=brainmass.OUProcess(in_size=N_regions, sigma=0.1, tau=30. * u.ms),
    )
+   brainstate.nn.init_all_states(network)
 
-   # Add noise to each population
-   network.noise_E = brainmass.OUProcess(
-       in_size=N_regions,
-       sigma=0.3 * u.Hz,
-       tau=20. * u.ms
-   )
-
-   network.noise_I = brainmass.OUProcess(
-       in_size=N_regions,
-       sigma=0.2 * u.Hz,
-       tau=30. * u.ms
-   )
-
-   # Initialize
-   network.init_all_states()
-
-   # Simulate
    def step(i):
-       return network.update(rE_inp=0.5, rI_inp=0.2)
-
-   exc_rates = brainstate.transform.for_loop(step, jnp.arange(2000))
+       with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+           return network.update(rE_inp=0.5, rI_inp=0.2)
 
    # exc_rates has shape (2000, 10) - excitatory rates for 10 regions
+   exc_rates = brainstate.transform.for_loop(step, np.arange(2000))
 
 
-**Note:** ``in_size=N_regions`` creates N independent copies of the model (no coupling yet).
+**Note:** ``in_size=N_regions`` creates ``N`` independent copies of the model (no coupling yet).
 
 
 Adding Coupling
 ---------------
 
-Connect regions with diffusive coupling:
+To connect regions, build a coupling term from a connectivity matrix. ``DiffusiveCoupling``
+reads each node's state through a *prefetch* (optionally delayed), multiplies by the
+connectivity, and returns a per-node current you feed back into ``update``:
 
-.. code-block:: python
+.. testcode::
 
    import brainmass
-   import jax.numpy as jnp
-   import brainunit as u
    import brainstate
+   import braintools
+   import brainunit as u
+   import numpy as np
+   import jax.numpy as jnp
 
+   brainstate.environ.set(dt=0.1 * u.ms)
    N = 10
 
-   # Create connectivity matrix (random for demo)
-   W = jax.random.uniform(jax.random.PRNGKey(0), (N, N)) * 0.1
-   W = W.at[jnp.diag_indices(N)].set(0.)  # no self-connections
+   nodes = brainmass.HopfStep(in_size=N, a=0.25, w=0.3)
 
-   # Create models
-   nodes = brainmass.HopfOscillator(in_size=N, omega=10 * u.Hz)
-   coupling = brainmass.DiffusiveCoupling(conn=W, k=0.2)
+   # Connectivity matrix (random for demo), no self-connections
+   W = np.random.RandomState(0).rand(N, N) * 0.1
+   np.fill_diagonal(W, 0.0)
+   W = jnp.asarray(W)
 
-   # Initialize
-   nodes.init_all_states()
-   coupling.init_all_states()
+   # Each target node reads every source node's (delayed) ``x`` -> shape (N, N)
+   delays = jnp.ones((N, N)) * (1.0 * u.ms)
+   src_idx = np.tile(np.arange(N)[None, :], (N, 1))
+   x_delayed = nodes.prefetch_delay('x', delays, src_idx, init=braintools.init.ZeroInit())
+   x_local = nodes.prefetch('x')
 
-   # Network simulation with coupling
+   coupling = brainmass.DiffusiveCoupling(x_delayed, x_local, conn=W, k=0.2)
+
+   brainstate.nn.init_all_states(nodes)
+   brainstate.nn.init_all_states(coupling)  # the coupling owns the delay buffer
+
    def network_step(i):
-       x = nodes.x.value
-       coupled_input = coupling(x, x)
+       with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+           coupled_input = coupling.update()    # (N,) coupling current
+           nodes.update(coupled_input, 0.0)     # feed it as the x input
+           return nodes.x.value
 
-       output = nodes.update()
-       nodes.x.value += coupled_input  # add coupling to state
-
-       return output
-
-   network_activity = brainstate.transform.for_loop(
-       network_step,
-       jnp.arange(1000)
-   )
+   network_activity = brainstate.transform.for_loop(network_step, np.arange(1000))
 
 
 Forward Modeling (BOLD Signal)
 -------------------------------
 
-Map neural activity to fMRI BOLD signal:
+Map neural activity to an fMRI BOLD signal with the Balloon-Windkessel ``BOLDSignal`` model.
+The neural model integrates with a ``dt`` carrying time units, while ``BOLDSignal`` is fully
+dimensionless and expects a **unitless** ``dt`` -- so the two stages set ``dt`` separately:
 
-.. code-block:: python
+.. testcode::
 
    import brainmass
-   import jax.numpy as jnp
-   import brainunit as u
    import brainstate
+   import brainunit as u
+   import numpy as np
 
    N_regions = 5
 
-   # Neural mass model
-   nmm = brainmass.WilsonCowanModel(in_size=N_regions)
+   # --- neural stage (dt carries time units) ---
+   brainstate.environ.set(dt=0.1 * u.ms)
+   nmm = brainmass.WilsonCowanStep(in_size=N_regions)
    nmm.init_all_states()
 
-   # BOLD hemodynamic model
+   def sim_neural(i):
+       with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+           return nmm.update(rE_inp=0.5, rI_inp=0.2)
+
+   neural_activity = brainstate.transform.for_loop(sim_neural, np.arange(2000))
+
+   # --- haemodynamic stage (BOLDSignal needs a dimensionless dt) ---
+   brainstate.environ.set(dt=0.01)
    bold_model = brainmass.BOLDSignal(in_size=N_regions)
    bold_model.init_all_states()
 
-   # Simulate neural activity
-   def sim_neural(i):
-       return nmm.update(rE_inp=0.5, rI_inp=0.2)
-
-   neural_activity = brainstate.transform.for_loop(
-       sim_neural,
-       jnp.arange(5000)  # 5000 time steps
-   )
-
-   # Generate BOLD signal from neural activity
    def sim_bold(z):
-       bold_model.update(z=z)
-       return bold_model.bold()
+       bold_model.update(z)        # update() returns None; it mutates state
+       return bold_model.bold()    # read the BOLD observable
 
-   bold_signal = brainstate.transform.for_loop(
-       sim_bold,
-       neural_activity
-   )
+   bold_signal = brainstate.transform.for_loop(sim_bold, neural_activity)
+   # bold_signal has shape (2000, 5)
 
-   # bold_signal shape: (5000, 5)
-   # Downsample to TR ~ 2s if needed: bold_signal[::2000]
+   brainstate.environ.set(dt=0.1 * u.ms)  # restore the time-unit dt for later code
 
 
 Common Patterns
@@ -227,40 +230,43 @@ Common Patterns
 
 **Pattern 1: Batched Simulations**
 
-Run multiple simulations in parallel:
+Run multiple independent simulations in parallel with ``batch_size``:
 
-.. code-block:: python
+.. testcode::
 
+   brainstate.environ.set(dt=0.1 * u.ms)
    batch_size = 32
 
-   model = brainmass.HopfOscillator(in_size=10, omega=10 * u.Hz)
+   model = brainmass.HopfStep(in_size=10, w=0.2)
    model.init_all_states(batch_size=batch_size)
 
-   output = model.update()  # shape: (32, 10)
+   model.update()
+   x = model.x.value  # shape: (32, 10)
 
 
 **Pattern 2: Accessing Internal States**
 
-.. code-block:: python
+.. testcode::
 
-   model = brainmass.WilsonCowanModel(in_size=5)
+   model = brainmass.WilsonCowanStep(in_size=5)
    model.init_all_states()
 
    model.update(rE_inp=0.5, rI_inp=0.2)
 
    # Access internal state variables
-   exc_rate = model.rE.value  # excitatory firing rate
-   inh_rate = model.rI.value  # inhibitory firing rate
+   exc_rate = model.rE.value  # excitatory firing rate, shape (5,)
+   inh_rate = model.rI.value  # inhibitory firing rate, shape (5,)
 
 
 **Pattern 3: Custom Time Steps**
 
-.. code-block:: python
+.. testcode::
 
-   # Default dt is typically 1 ms
-   # To change, set during model creation or manually integrate
+   # dt is global; set it through the environment (not a model argument)
+   brainstate.environ.set(dt=0.5 * u.ms)
 
-   model = brainmass.HopfOscillator(in_size=1, omega=10 * u.Hz, dt=0.5 * u.ms)
+   model = brainmass.HopfStep(in_size=1, w=0.2)
+   model.init_all_states()
 
 
 Quick Reference
@@ -272,16 +278,18 @@ Quick Reference
 
    * - Task
      - Code
+   * - Set the time step
+     - ``brainstate.environ.set(dt=0.1 * u.ms)``
    * - Create model
-     - ``model = brainmass.ModelName(in_size=N, **params)``
+     - ``model = brainmass.HopfStep(in_size=N, **params)``
    * - Initialize state
      - ``model.init_all_states(batch_size=None)``
    * - Single step
      - ``output = model.update(**inputs)``
    * - Simulate loop
-     - ``brainstate.transform.for_loop(lambda i: model.update(), jnp.arange(T))``
+     - ``brainstate.transform.for_loop(step, jnp.arange(T))``
    * - Add noise
-     - ``model.noise = brainmass.OUProcess(in_size=N, sigma=..., tau=...)``
+     - ``brainmass.HopfStep(in_size=N, noise_x=..., noise_y=...)``
    * - Access state
      - ``value = model.state_var.value``
    * - Reset state
@@ -305,7 +313,7 @@ Tips for Beginners
 - **Start simple:** Single region, no noise, no coupling
 - **Visualize often:** Plot time series to understand dynamics
 - **Check units:** Use ``brainunit`` quantities to avoid unit errors
-- **Read docstrings:** Use ``help(brainmass.ModelName)`` for parameter details
+- **Read docstrings:** Use ``help(brainmass.HopfStep)`` for parameter details
 - **Use examples:** The :doc:`../examples/index` are your best resource
 
 

--- a/docs/tutorials/units_guide.rst
+++ b/docs/tutorials/units_guide.rst
@@ -202,14 +202,15 @@ Internal states maintain units:
 
    model = brainmass.HopfStep(
        in_size=5,
-       omega=10 * u.Hz,
+       w=0.2,  # intrinsic angular frequency (dimensionless)
    )
    model.init_all_states()
 
    model.update()
 
-   # States have units if specified
-   x = model.x.value  # has units from model definition
+   # In the normal-form Hopf model the state is dimensionless; models such as
+   # JansenRitStep instead keep their internal states in physical units (e.g. mV).
+   x = model.x.value
    y = model.y.value
 
 

--- a/docs/tutorials/units_guide.rst
+++ b/docs/tutorials/units_guide.rst
@@ -184,7 +184,7 @@ Most brainmass models accept unit quantities:
    import brainmass
    import brainunit as u
 
-   model = brainmass.WilsonCowanModel(
+   model = brainmass.WilsonCowanStep(
        in_size=10,
        tau_E=10. * u.ms,    # with units
        tau_I=20. * u.ms,
@@ -200,7 +200,7 @@ Internal states maintain units:
 
 .. code-block:: python
 
-   model = brainmass.HopfOscillator(
+   model = brainmass.HopfStep(
        in_size=5,
        omega=10 * u.Hz,
    )


### PR DESCRIPTION
## Summary

Brings the documentation back in line with the real `*Step` API and makes it self-checking so it cannot silently drift again.

### API drift eliminated
- Renamed every legacy class reference across `docs/` + `README.md` to its canonical `*Step` name (`HopfOscillator`→`HopfStep`, `WilsonCowanModel`→`WilsonCowanStep`, `WongWangModel`→`WongWangStep`, `JansenRitModel`→`JansenRitStep`, `FitzHughNagumoModel`→`FitzHughNagumoStep`, `ThresholdLinearModel`→`ThresholdLinearStep`, `StuartLandauOscillator`→`StuartLandauStep`, `VanDerPolOscillator`→`VanDerPolStep`, `QIF`/`QIFModel`→`MontbrioPazoRoxinStep`). DoD grep over `docs/` is empty.
- Fixed never-runnable calls: `HopfStep` takes a dimensionless `w`, not `omega=…*u.Hz`; `DiffusiveCoupling` is built from `prefetch_delay`/`prefetch` references, not `conn=`+`coupling(src,tgt)`.
- The `__getattr__` deprecation shim is **untouched** — the docs simply stop relying on the old names.

### Docs are now self-checking
- Enabled `sphinx.ext.doctest`. Quickstart and the canonical coupling examples (building_networks, adding_coupling) are executed `.. testcode::`; docstring `>>>` examples are checked. `sphinx-build -b doctest` → **48 tests, 0 failures**.
- Data-dependent / conceptual tutorials (forward_modeling, parameter_fitting, building_networks whole-brain example) are explicitly marked **schematic / not executed** with a note, per the goal's allowance. Notebook execution stays off.
- Merged the duplicate `autodoc_default_options` in `docs/conf.py` (the second copy had been silently disabling member documentation).

### Other deliverables
- `README.md`: runnable Quick Start snippet + citation version `0.0.4`→`0.0.6`.
- `changelog.md`: new `0.0.6` entry (goal-01 correctness fixes + this docs work).
- `developer/contributing.rst`: NumPy (not Google) docstrings; tests are co-located `brainmass/<m>_test.py` (`pytest brainmass/`, no `tests/` dir); `.[dev,doc]` extras don't exist yet → install via `requirements-doc.txt` (consolidated extras are goal-03).

### Verification
- `pytest brainmass/`: **229 passed, 1 xfailed** (the goal-01 JansenRitNetwork multi-layer xfail).
- `sphinx-build -b doctest`: 48/48.
- DoD grep over `docs/` + `README.md`: empty.

Lessons appended to `CONTEXT.md` (`### 2026-06-18 · goal-02 docs-integrity`).