### PR TITLE
test: differentiability + determinism + coverage safety net (goal-04)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
           pip install .  --no-cache-dir
       - name: Test with pytest
         run: |
-          pytest brainmass/
+          pytest brainmass/ --cov=brainmass --cov-report=term-missing --cov-fail-under=90
 
 
   test_macos:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,13 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
 - `forward_model.py` `LeadFieldModel` — docstring/shape drift; `_sample_noise` references a
   nonexistent `self._noise_cov_q`.
 - `jansen_rit.py` — `s_max` default mismatch (docstring 2.5 Hz vs code 5.0 Hz).
+- `qif.py` `MontbrioPazoRoxinStep.update` (~line 260, non-`exp_euler` branch) — calls
+  `ode_<method>_step((r, v), 0.*u.ms, r_inp, v_inp)` and **omits `self.derivative`** as the
+  first positional arg, so `braintools.quad.ode_rk2_step`/`ode_rk4_step` get the state tuple
+  where the vector field should be → `TypeError: input function should be callable`. Only the
+  default `exp_euler` path works; `method='rk2'|'rk4'` is dead. Found in goal-04 (integrator
+  sweep), parked as **2 strict `xfail`s** in `integrator_test.py` (so the fix flips them to
+  pass). Fix in goal-05.
 
 ## Known drift / debt
 
@@ -185,3 +192,38 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
   must be committed-to early — a native/empty worktree got auto-cleaned ("unchanged") mid-session.
   And the same drvfs absolute-path trap as goal-01: file tools with an absolute path to the MAIN
   checkout write to main, not the worktree.
+
+### 2026-06-18 · goal-04 testing-rigor
+- **Headline delivered — gradients now tested.** New `gradient_test.py` (23 tests) proves AD flows
+  through a `for_loop` sim for Hopf/WilsonCowan/JansenRit/Montbrio/FitzHughNagumo: grad-vs-FD,
+  `jax.test_util.check_grads(modes=['rev'])`, vmap-batched grads, zero-noise-limit, and
+  determinism-under-seeding. Net suite **229→311 passed (+3 xfail)**; coverage **77%→97.85%**,
+  every module ≥ 91.8%.
+- **Differentiable-test recipe (reuse this):** build the model *inside* the loss with the swept
+  scalar as `Param(p, fit=True)`, `brainstate.random.seed(0)` FIRST (purity — unseeded `Uniform`
+  init silently breaks check_grads/FD), run `for_loop`, reduce with `jnp.sum(u.get_magnitude(xs)**2)`
+  (**must** strip units or grad carries mV²/Hz² and FD comparison explodes). Pick a param the loss
+  is actually sensitive to: Montbrio grad wrt `J` at rest is ~1e-6 (FD noise drowns it) — swept
+  `eta` with a `v_inp=1.0` drive instead (AD=FD=0.1378). FD tol `rel=2e-2, abs=1e-6`.
+- **exp_euler is EXACT on linear ODEs** → use as analytic oracle (`integrator_test.py` asserts
+  err<1e-5 on linear decay, plus convergence-order bands exp_euler≈1 / rk2≈2). rk4 on smooth
+  nonlinear systems floors at float32 round-off ~8e-7, not 1e-12 — don't assert tighter.
+- **Systemic seeding bug found across the suite:** helpers seeded `brainstate.random` but built data
+  with `np.random.*` (uncontrolled). Both RNGs must be seeded. Fixed in noise/coupling/horn/
+  jansen_rit/leadfield/wong_wang tests; conftest `seeded` fixture seeds both.
+- **conftest extended (not replaced):** autouse `_isolate_environ_dt` snapshots/restores global
+  `environ['dt']` — this leakage was real (`jansen_rit` `test_eeg_output_signal` had been passing
+  only on a dt leaked from an earlier test). Plus `dt`/`seeded`/`connectome` fixtures, all
+  `indirect=`-parametrizable. `matplotlib.use("Agg")` at import top makes `plt.show()` a no-op.
+- **Dead tests repaired:** 5 commented `test_stability_long_simulation` (WC variants) uncommented +
+  converted slow `for i in range(10000)` python loops → jitted `for_loop` (all stay bounded <0.5);
+  Jansen/WongWang `plot=True` demos flipped to `plot=False` default (+ seeded WongWang) and given
+  finiteness/transient/bounded-gating asserts instead of bare `return`. A wrong commented Jansen
+  assertion (`out[-1] >= out[0]`; output is non-monotonic) was replaced with a responsiveness check.
+- **Coverage gate is now standard `pytest-cov`** (`pyproject [tool.coverage] fail_under=90, branch,
+  omit *_test.py`; CI Linux job runs `--cov=brainmass --cov-fail-under=90`; macOS/Win stay plain).
+  **The goal-01 drvfs coverage-SIGABRT did NOT recur** — full suite under plain `pytest --cov` ran
+  clean on `/mnt/d` (EXIT=0), so the `dev/superpowers/run_cov.py` C-ext-ordering workaround was
+  needed only locally before and is NOT shipped. `pytest-cov`+`coverage` added to requirements-dev.
+- **For goal-05:** see the new `qif.py` entry under *Known latent bugs* — the 2 strict `xfail`s in
+  `integrator_test.py` flip to pass the moment `self.derivative` is restored.

--- a/brainmass/branch_coverage_test.py
+++ b/brainmass/branch_coverage_test.py
@@ -1,0 +1,97 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Targeted tests for otherwise-uncovered branches.
+
+These cover the small, easy-to-miss code paths that the model behaviour tests do
+not reach: the abstract base ``XY_Oscillator`` right-hand sides, the noise
+injection branches of the FitzHugh-Nagumo and Montbrio-Pazo-Roxin models, and
+the deprecated-alias ``__getattr__`` shim of the package.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import brainstate
+import brainunit as u
+
+import brainmass
+from brainmass._xy_model import XY_Oscillator
+
+
+def test_xy_oscillator_base_rhs_not_implemented(dt):
+    """The abstract ``XY_Oscillator`` leaves ``dx``/``dy`` to subclasses."""
+    model = XY_Oscillator(2)
+    brainstate.nn.init_all_states(model)
+    with pytest.raises(NotImplementedError):
+        model.dx(model.x.value, model.y.value, 0.0)
+    with pytest.raises(NotImplementedError):
+        model.dy(model.y.value, model.x.value, 0.0)
+
+
+def _reproducible_noise_run(make_model, seed=0, n_steps=20):
+    """Run a noisy model twice under a fixed seed and return both trajectories."""
+    def once():
+        brainstate.random.seed(seed)
+        model = make_model()
+        brainstate.nn.init_all_states(model)
+
+        def step(i):
+            with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+                return model.update()
+
+        return np.asarray(u.get_magnitude(
+            brainstate.transform.for_loop(step, np.arange(n_steps))))
+
+    return once(), once()
+
+
+def test_montbrio_noise_paths_are_seeded(dt):
+    """Both noise channels of MontbrioPazoRoxin run and are reproducible."""
+    a, b = _reproducible_noise_run(
+        lambda: brainmass.MontbrioPazoRoxinStep(
+            2,
+            noise_r=brainmass.GaussianNoise(2, sigma=1.0 * u.Hz),
+            noise_v=brainmass.GaussianNoise(2, sigma=0.1)))
+    assert np.all(np.isfinite(a))
+    assert np.array_equal(a, b)
+
+
+def test_fhn_noise_paths_are_seeded(dt):
+    """Both noise channels of FitzHugh-Nagumo run and are reproducible."""
+    a, b = _reproducible_noise_run(
+        lambda: brainmass.FitzHughNagumoStep(
+            2,
+            noise_V=brainmass.GaussianNoise(2, sigma=0.1),
+            noise_w=brainmass.GaussianNoise(2, sigma=0.1)))
+    assert np.all(np.isfinite(a))
+    assert np.array_equal(a, b)
+
+
+def test_deprecated_model_alias_warns_and_resolves():
+    """Legacy ``*Model`` names resolve to their ``*Step`` class with a warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        cls = brainmass.WilsonCowanModel  # legacy alias for WilsonCowanStep
+    assert cls is brainmass.WilsonCowanStep
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_unknown_attribute_raises():
+    """An attribute that is neither current nor a legacy alias raises."""
+    with pytest.raises(AttributeError):
+        _ = brainmass.DefinitelyNotAModelName

--- a/brainmass/coupling_test.py
+++ b/brainmass/coupling_test.py
@@ -292,6 +292,7 @@ class TestSharedRecurrentConn:
         brainstate.environ.set(dt=0.1 * u.ms)
         model = brainmass.HORNStep(4)
         brainstate.nn.init_all_states(model)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(4, 4)).astype('float32')) * u.ms
         conn = DelayedAdditiveConn(model, delay_time=delay, state='y')
         brainstate.nn.init_all_states(conn)

--- a/brainmass/gradient_test.py
+++ b/brainmass/gradient_test.py
@@ -1,0 +1,278 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Differentiability / gradient tests for the representative neural-mass models.
+
+``brainmass`` advertises itself as a *differentiable* whole-brain modelling
+library, yet historically shipped **zero** gradient tests. This module installs
+that safety net: for each representative model it asserts that a gradient flows
+through a short :func:`brainstate.transform.for_loop` simulation with respect to
+a trainable :class:`brainstate.nn.Param`, cross-checks reverse-mode autodiff
+against finite differences, and runs :func:`jax.test_util.check_grads`.
+
+Notes
+-----
+Two facts make these tests work and are easy to get wrong:
+
+1. Model parameters are **non-trainable by default** -- ``Param.init(scalar, shape)``
+   wraps the value in a ``Const`` (``fit=False``). To obtain a trainable
+   ``ParamState`` the model must be constructed with ``Param(value, fit=True)``;
+   only then does ``model.states(brainstate.ParamState)`` find the parameter.
+2. The loss function must be **deterministic**. Several models default to random
+   (``Uniform``) state initializers; without seeding, each evaluation of the loss
+   starts from a different state and the finite-difference / ``check_grads``
+   cross-checks fail spuriously. Every loss below seeds the RNG first.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.test_util import check_grads
+
+import brainstate
+import brainunit as u
+from brainstate.nn import Param
+
+import brainmass
+
+# A short horizon keeps the tests fast while still exercising recurrence.
+N_STEP = 40
+IN_SIZE = 2
+SEED = 0
+
+
+def _scalar_loss(model, drive, read):
+    """Run a short deterministic simulation and return a scalar loss.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Dynamics
+        An already-initialised model instance.
+    drive : callable
+        ``drive(model)`` advances the model by one step (calls ``model.update``).
+    read : callable
+        ``read(model)`` returns the state quantity to accumulate into the loss.
+
+    Returns
+    -------
+    jax.Array
+        ``sum(read(model) ** 2)`` over the trajectory, with physical units
+        stripped so the result is a plain scalar.
+    """
+    def step(i):
+        with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+            drive(model)
+            return read(model)
+
+    xs = brainstate.transform.for_loop(step, np.arange(N_STEP))
+    return jnp.sum(u.get_magnitude(xs) ** 2)
+
+
+# Each spec builds a model whose named parameter is trainable, drives it, and
+# reads a state. ``p0`` is the operating point for the gradient checks.
+# ``strong`` flags models whose gradient is robustly far from zero (used for the
+# extra "gradient is non-trivial" assertion); models with legitimately tiny
+# gradients are still validated by the AD-vs-FD and check_grads cross-checks.
+def _hopf(p):
+    return brainmass.HopfStep(IN_SIZE, a=Param(p, fit=True))
+
+
+def _wilson_cowan(p):
+    return brainmass.WilsonCowanStep(IN_SIZE, wEE=Param(p, fit=True))
+
+
+def _jansen_rit(p):
+    return brainmass.JansenRitStep(IN_SIZE, C=Param(p, fit=True))
+
+
+def _montbrio(p):
+    # Differentiate w.r.t. the excitability ``eta`` while driving the membrane
+    # potential, so the population is in an active regime where the parameter
+    # genuinely influences the firing rate (the gradient w.r.t. ``J`` at rest is
+    # ~1e-6 and dominated by round-off, which makes a meaningful check impossible).
+    return brainmass.MontbrioPazoRoxinStep(IN_SIZE, eta=Param(p, fit=True))
+
+
+def _fhn(p):
+    return brainmass.FitzHughNagumoStep(IN_SIZE, alpha=Param(p, fit=True))
+
+
+SPECS = {
+    "hopf": dict(build=_hopf, drive=lambda m: m.update(0.1, 0.0),
+                 read=lambda m: m.x.value, p0=0.3, strong=True),
+    "wilson_cowan": dict(build=_wilson_cowan, drive=lambda m: m.update(rE_inp=1.0),
+                         read=lambda m: m.rE.value, p0=10.0, strong=True),
+    "jansen_rit": dict(build=_jansen_rit, drive=lambda m: m.update(M_inp=3.0 * u.mV),
+                       read=lambda m: m.E.value - m.I.value, p0=135.0, strong=False),
+    "montbrio": dict(build=_montbrio, drive=lambda m: m.update(v_inp=1.0),
+                     read=lambda m: m.r.value, p0=-5.0, strong=True),
+    "fhn": dict(build=_fhn, drive=lambda m: m.update(V_inp=0.5),
+                read=lambda m: m.V.value, p0=3.0, strong=True),
+}
+MODELS = list(SPECS)
+
+
+def _pure_loss(spec):
+    """Return a pure ``f(pval) -> scalar`` for a model spec.
+
+    The returned function seeds the RNG, builds the model with a trainable
+    parameter set to ``pval``, initialises its states, and returns the scalar
+    simulation loss. Seeding makes ``f`` a genuine (deterministic) function of
+    ``pval`` even for models with random default initializers.
+    """
+    def f(pval):
+        brainstate.random.seed(SEED)
+        model = spec["build"](pval)
+        brainstate.nn.init_all_states(model)
+        return _scalar_loss(model, spec["drive"], spec["read"])
+
+    return f
+
+
+@pytest.fixture(autouse=True)
+def _dt(dt):
+    """Install a known time step for every gradient test (uses the ``dt`` fixture)."""
+    return dt
+
+
+@pytest.mark.parametrize("name", MODELS)
+def test_grad_flows_through_for_loop(name):
+    """A gradient w.r.t. a trainable ``Param`` flows through a ``for_loop`` sim.
+
+    Uses the ``brainstate.transform.grad`` idiom over ``model.states(ParamState)``
+    -- the same path a user fitting the model would take.
+    """
+    spec = SPECS[name]
+    brainstate.random.seed(SEED)
+    model = spec["build"](jnp.asarray(spec["p0"], dtype=float))
+    brainstate.nn.init_all_states(model)
+
+    weights = model.states(brainstate.ParamState)
+    assert len(weights) == 1, "exactly one trainable Param expected"
+
+    def loss():
+        return _scalar_loss(model, spec["drive"], spec["read"])
+
+    grads, value = brainstate.transform.grad(loss, weights, return_value=True)()
+
+    leaves = jax.tree.leaves(grads)
+    assert leaves, "grad tree is empty -- no ParamState was differentiated"
+    for g in leaves:
+        assert jnp.all(jnp.isfinite(g)), f"{name}: non-finite gradient"
+    assert jnp.isfinite(value)
+
+
+@pytest.mark.parametrize("name", MODELS)
+def test_value_and_grad(name):
+    """``jax.value_and_grad`` over the pure loss returns a finite value+grad."""
+    spec = SPECS[name]
+    f = _pure_loss(spec)
+    value, grad = jax.value_and_grad(f)(jnp.asarray(spec["p0"], dtype=float))
+    assert jnp.isfinite(value)
+    assert jnp.isfinite(grad)
+    if spec["strong"]:
+        assert abs(float(grad)) > 1e-3, (
+            f"{name}: gradient ~0 ({float(grad):.2e}); flow likely blocked"
+        )
+
+
+@pytest.mark.parametrize("name", MODELS)
+def test_ad_matches_finite_difference(name):
+    """Reverse-mode AD agrees with a central finite difference.
+
+    This is the core *correctness* check: it validates the gradient value (not
+    merely that something finite came back), and works even for models whose
+    gradient is legitimately small.
+    """
+    spec = SPECS[name]
+    f = _pure_loss(spec)
+    p0 = float(spec["p0"])
+    ad = float(jax.grad(f)(jnp.asarray(p0)))
+
+    eps = 1e-3 * max(1.0, abs(p0))
+    fd = (float(f(jnp.asarray(p0 + eps))) - float(f(jnp.asarray(p0 - eps)))) / (2 * eps)
+
+    assert ad == pytest.approx(fd, rel=2e-2, abs=1e-6), (
+        f"{name}: AD={ad:.6g} disagrees with finite-difference={fd:.6g}"
+    )
+
+
+@pytest.mark.parametrize("name", MODELS)
+def test_check_grads(name):
+    """``jax.test_util.check_grads`` passes (reverse mode, first order)."""
+    spec = SPECS[name]
+    f = _pure_loss(spec)
+    check_grads(f, (jnp.asarray(float(spec["p0"])),), order=1, modes=["rev"],
+                rtol=2e-2, atol=2e-2)
+
+
+def test_grad_through_stochastic_model_is_deterministic():
+    """Gradient through a *stochastic* model is finite and reproducible when seeded.
+
+    Seeding the RNG before building the model makes the noise realisation -- and
+    therefore the gradient -- bit-for-bit reproducible, which is what allows
+    stochastic models to be fitted with gradient methods at all.
+    """
+    def grad_once():
+        brainstate.random.seed(123)
+        noise = brainmass.GaussianNoise(IN_SIZE, sigma=0.3)  # unitless to match Hopf x
+        model = brainmass.HopfStep(IN_SIZE, a=Param(jnp.asarray(0.3), fit=True),
+                                   noise_x=noise)
+        brainstate.nn.init_all_states(model)
+        weights = model.states(brainstate.ParamState)
+
+        def loss():
+            return _scalar_loss(model, lambda m: m.update(0.1, 0.0), lambda m: m.x.value)
+
+        grads, value = brainstate.transform.grad(loss, weights, return_value=True)()
+        return float(jax.tree.leaves(grads)[0]), float(value)
+
+    g1, v1 = grad_once()
+    g2, v2 = grad_once()
+    assert np.isfinite(g1) and np.isfinite(v1)
+    assert g1 == g2, "seeded stochastic gradient is not reproducible"
+    assert v1 == v2
+
+
+def test_vmap_batched_gradients():
+    """Batched (``vmap``) gradients over a sweep of parameter values are finite."""
+    f = _pure_loss(SPECS["hopf"])
+    p_values = jnp.array([0.1, 0.2, 0.3, 0.4])
+    batched = jax.vmap(jax.grad(f))(p_values)
+    assert batched.shape == (4,)
+    assert jnp.all(jnp.isfinite(batched))
+    # Different operating points should give different gradients.
+    assert float(jnp.std(batched)) > 1e-3
+
+
+def test_zero_noise_limit_recovers_deterministic_gradient():
+    """With zero-amplitude noise the stochastic path equals the noise-free path."""
+    def grad_with(noise):
+        brainstate.random.seed(7)
+        model = brainmass.HopfStep(IN_SIZE, a=Param(jnp.asarray(0.3), fit=True),
+                                   noise_x=noise)
+        brainstate.nn.init_all_states(model)
+        weights = model.states(brainstate.ParamState)
+        grads = brainstate.transform.grad(
+            lambda: _scalar_loss(model, lambda m: m.update(0.1, 0.0),
+                                 lambda m: m.x.value),
+            weights,
+        )()
+        return float(jax.tree.leaves(grads)[0])
+
+    g_zero_noise = grad_with(brainmass.GaussianNoise(IN_SIZE, sigma=0.0))
+    g_no_noise = grad_with(None)
+    assert g_zero_noise == pytest.approx(g_no_noise, rel=1e-5, abs=1e-6)

--- a/brainmass/horn_test.py
+++ b/brainmass/horn_test.py
@@ -26,6 +26,7 @@ from brainmass.horn import HORN_TR
 
 def _seq(T, n, seed=0):
     brainstate.random.seed(seed)
+    np.random.seed(seed)  # the sequence below uses numpy's RNG, not brainstate's
     return jnp.asarray(np.random.randn(T, n).astype('float32'))
 
 
@@ -51,6 +52,7 @@ class TestHORNSeqLayer:
 
     def test_delayed_path(self):
         brainstate.environ.set(dt=0.1 * u.ms)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype('float32')) * u.ms
         m = brainmass.HORNSeqLayer(3, 5, delay=delay)
         brainstate.nn.init_all_states(m)
@@ -98,6 +100,7 @@ class TestHORN_TR:
     def test_rec_types(self, rec_type, with_delay):
         brainstate.environ.set(dt=0.1 * u.ms)
         n = 5
+        np.random.seed(0)  # deterministic delay matrix
         delay = (jnp.asarray(np.random.randint(1, 4, size=(n, n)).astype('float32')) * u.ms
                  if with_delay else None)
         kwargs = dict(tr=0.5 * u.ms)
@@ -110,6 +113,7 @@ class TestHORN_TR:
 
     def test_unknown_rec_type_raises(self):
         brainstate.environ.set(dt=0.1 * u.ms)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype('float32')) * u.ms
         with pytest.raises(ValueError):
             HORN_TR(5, delay=delay, rec_type='nope')

--- a/brainmass/integrator_test.py
+++ b/brainmass/integrator_test.py
@@ -1,0 +1,184 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Integrator (ODE solver) sweeps and convergence-order tests.
+
+Every model exposes a ``method`` argument selecting the integration scheme
+(``exp_euler`` by default, or any ``braintools.quad.ode_<method>_step``). These
+tests sweep ``method`` across representative models -- exercising the non-default
+``derivative`` code paths that were otherwise untested -- and verify the schemes
+are not just finite but *correct*, using analytic oracles and measured
+convergence orders.
+"""
+
+import numpy as np
+import pytest
+
+import braintools
+import brainstate
+import brainunit as u
+
+import brainmass
+
+METHODS = ["exp_euler", "rk2", "rk4"]
+
+
+def _simulate_last(model, drive, read, n_steps):
+    """Advance ``model`` for ``n_steps`` and return the final read value (NumPy)."""
+    def step(i):
+        with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+            drive(model)
+            return read(model)
+
+    xs = brainstate.transform.for_loop(step, np.arange(n_steps))
+    return np.asarray(u.get_magnitude(xs[-1])).reshape(-1)
+
+
+# Build/drive/read recipes per model, parametrized by integration ``method``.
+SWEEP = {
+    "hopf": dict(
+        build=lambda method: brainmass.HopfStep(2, a=-0.2, method=method),
+        drive=lambda m: m.update(0.1, 0.0),
+        read=lambda m: m.x.value,
+    ),
+    "fhn": dict(
+        build=lambda method: brainmass.FitzHughNagumoStep(
+            2, method=method,
+            init_V=braintools.init.Constant(0.1), init_w=braintools.init.ZeroInit()),
+        drive=lambda m: m.update(V_inp=0.3),
+        read=lambda m: m.V.value,
+    ),
+    "montbrio": dict(
+        build=lambda method: brainmass.MontbrioPazoRoxinStep(
+            2, method=method,
+            init_r=braintools.init.ZeroInit(unit=u.Hz), init_v=braintools.init.ZeroInit()),
+        drive=lambda m: m.update(v_inp=0.5),
+        read=lambda m: m.r.value,
+    ),
+    "wilson_cowan": dict(
+        build=lambda method: brainmass.WilsonCowanStep(2, method=method),
+        drive=lambda m: m.update(rE_inp=1.0),
+        read=lambda m: m.rE.value,
+    ),
+}
+
+
+_MONTBRIO_RK_XFAIL = pytest.mark.xfail(
+    reason="LATENT BUG (deferred to goal-05): qif.py MontbrioPazoRoxinStep.update "
+           "non-exp_euler branch calls ode_<method>_step((r, v), ...) without passing "
+           "self.derivative as the first (function) argument -- cf. the correct calls in "
+           "_xy_model.py and fhn.py. So method in {rk2, rk4} raises 'input function should "
+           "be callable'.",
+    strict=True,
+    raises=AssertionError,
+)
+
+
+def _sweep_cases():
+    """Build (model, method) cases; mark the known-broken montbrio rk2/rk4 xfail."""
+    cases = []
+    for model_name in SWEEP:
+        for method in METHODS:
+            marks = (_MONTBRIO_RK_XFAIL
+                     if model_name == "montbrio" and method in ("rk2", "rk4") else ())
+            cases.append(pytest.param(model_name, method, marks=marks))
+    return cases
+
+
+@pytest.mark.parametrize("model_name, method", _sweep_cases())
+def test_method_runs_and_is_finite(model_name, method, dt):
+    """Each integrator produces a finite trajectory of the right shape."""
+    spec = SWEEP[model_name]
+    model = spec["build"](method)
+    brainstate.nn.init_all_states(model)
+    last = _simulate_last(model, spec["drive"], spec["read"], n_steps=50)
+    assert last.shape == (2,)
+    assert np.all(np.isfinite(last))
+
+
+def _hopf_linear_decay_final(method, dt_ms, a=-1.0, x0=1.0, T_ms=5.0):
+    """Integrate the *linear* Hopf reduction ``dx/dt = a*x`` and return ``x(T)``.
+
+    With ``w=0`` and ``beta=0`` the Hopf node reduces to scalar linear decay,
+    whose exact solution is ``x(T) = x0 * exp(a * T)``. This is an analytic
+    oracle for the integrators.
+    """
+    brainstate.environ.set(dt=dt_ms * u.ms)
+    m = brainmass.HopfStep(
+        1, a=a, w=0.0, beta=0.0, method=method,
+        init_x=braintools.init.Constant(x0), init_y=braintools.init.ZeroInit())
+    brainstate.nn.init_all_states(m)
+    n = int(round(T_ms / dt_ms))
+    out = _simulate_last(m, lambda mm: mm.update(0.0, 0.0), lambda mm: mm.x.value, n)
+    return float(out[0])
+
+
+def test_exp_euler_is_exact_on_linear_decay():
+    """Exponential Euler integrates a linear ODE exactly (analytic oracle).
+
+    For ``dx/dt = a*x`` the exponential-Euler update is the exact propagator, so
+    the numerical solution must match ``exp(a*T)`` to round-off. ``rk4`` should be
+    near-exact, while the lower-order ``rk2`` carries a visibly larger error.
+    """
+    exact = np.exp(-5.0)  # a = -1, T = 5 ms
+    err_exp = abs(_hopf_linear_decay_final("exp_euler", 0.1) - exact)
+    err_rk4 = abs(_hopf_linear_decay_final("rk4", 0.1) - exact)
+    err_rk2 = abs(_hopf_linear_decay_final("rk2", 0.1) - exact)
+
+    assert err_exp < 1e-5, f"exp_euler not exact on linear decay: err={err_exp:.2e}"
+    assert err_rk4 < 1e-4, f"rk4 inaccurate on linear decay: err={err_rk4:.2e}"
+    assert err_rk2 > err_rk4, "rk2 should be less accurate than rk4 here"
+
+
+def _fhn_final(method, dt_ms, T_ms=4.0):
+    """Final ``V`` of a smooth nonlinear FitzHugh-Nagumo run (for order estimation)."""
+    brainstate.environ.set(dt=dt_ms * u.ms)
+    m = brainmass.FitzHughNagumoStep(
+        1, method=method,
+        init_V=braintools.init.Constant(0.5), init_w=braintools.init.Constant(0.1))
+    brainstate.nn.init_all_states(m)
+    n = int(round(T_ms / dt_ms))
+    out = _simulate_last(m, lambda mm: mm.update(V_inp=0.3), lambda mm: mm.V.value, n)
+    return float(out[0])
+
+
+@pytest.mark.parametrize(
+    "method, lo, hi",
+    [("exp_euler", 0.8, 1.3), ("rk2", 1.7, 2.3)],
+)
+def test_convergence_order(method, lo, hi):
+    """Global error shrinks at the scheme's theoretical order under dt-halving.
+
+    Measured against a fine ``rk4`` reference on a smooth nonlinear system,
+    ``exp_euler`` converges at first order and ``rk2`` at second order. (``rk4``
+    is excluded: at float32 it reaches the round-off floor before the asymptotic
+    order can be measured -- its accuracy is checked separately below.)
+    """
+    ref = _fhn_final("rk4", 0.001)
+    errs = [abs(_fhn_final(method, dt) - ref) for dt in (0.2, 0.1, 0.05)]
+    orders = [np.log2(errs[i] / errs[i + 1]) for i in range(len(errs) - 1)]
+    mean_order = float(np.mean(orders))
+    assert lo <= mean_order <= hi, (
+        f"{method}: measured order {mean_order:.2f} not in [{lo}, {hi}] (errs={errs})"
+    )
+
+
+def test_rk4_more_accurate_than_rk2():
+    """At a fixed step, the higher-order scheme is strictly more accurate."""
+    ref = _fhn_final("rk4", 0.001)
+    err_rk2 = abs(_fhn_final("rk2", 0.2) - ref)
+    err_rk4 = abs(_fhn_final("rk4", 0.2) - ref)
+    assert err_rk4 < err_rk2
+    assert err_rk4 < 1e-4

--- a/brainmass/jansen_rit_test.py
+++ b/brainmass/jansen_rit_test.py
@@ -198,6 +198,7 @@ class TestJansenRitModel:
 
     def test_eeg_output_signal(self):
         """Test EEG output signal computation."""
+        brainstate.environ.set(dt=1e-4 * u.second)  # self-contained: do not rely on leaked dt
         model = brainmass.JansenRitStep(in_size=1)
         model.init_state()
 
@@ -231,9 +232,9 @@ class TestJansenRitModel:
         indices = np.arange(n_steps)
         outputs = brainstate.transform.for_loop(step_run, indices)
 
-        # Check for oscillatory behavior
-        # The signal should not be constant
-        # assert u.math.std(outputs) > 0.1 * u.mV
+        # Check for oscillatory behavior: the signal must not be constant (it has
+        # a substantial transient before settling).
+        assert u.math.std(outputs) > 0.1 * u.mV
 
         # Check that states remain within reasonable bounds
         assert jnp.all(jnp.abs(model.M.value / u.mV) < 50.)
@@ -262,13 +263,15 @@ class TestJansenRitModel:
             out = brainstate.transform.for_loop(functools.partial(step_run, Ip=Ip), np.arange(5000))
             final_outputs.append(out[-1])
 
-        # Higher inputs should generally lead to larger output magnitudes
-        output_magnitudes = [u.math.abs(out) for out in final_outputs]
-
-        # # At least some progression with input level
-        # assert output_magnitudes[-1] >= output_magnitudes[0]
-        #
-        # print("[PASS] Input response test passed")
+        # The Jansen-Rit steady-state |output| is *not* monotonic in the pyramidal
+        # drive (the original `out[-1] >= out[0]` assertion was therefore wrong and
+        # was disabled). The meaningful, robust property is *responsiveness*: distinct
+        # drive levels must produce distinct, finite steady states.
+        final_mags = np.array([float(u.math.abs(out)[0] / u.mV) for out in final_outputs])
+        assert np.all(np.isfinite(final_mags)), "all steady-state responses must be finite"
+        assert final_mags.max() - final_mags.min() > 0.1, (
+            "model should respond to the input level (outputs span > 0.1 mV)"
+        )
 
     def test_parameter_sensitivity(self):
         """Test sensitivity to key parameters."""
@@ -371,7 +374,7 @@ class TestJansenRitModel:
         print("=" * 40)
         print("All JansenRit2Window tests passed! [PASS]")
 
-    def test_demo_alpha_rhythm(self, plot=True):
+    def test_demo_alpha_rhythm(self, plot=False):
         """Demonstrate alpha rhythm generation."""
         brainstate.environ.set(dt=0.0001 * u.second)  # 0.1 ms
 
@@ -428,9 +431,14 @@ class TestJansenRitModel:
             plt.show()
             plt.close()
 
-        return time, outputs
+        # The alpha-rhythm parameter set must produce a finite, non-trivial EEG
+        # transient before the model settles (full-trajectory std measured at
+        # ~0.27 mV; assert well above the post-settle float32 floor of ~1e-7 mV).
+        assert outputs.shape == (n_steps, 1)
+        assert u.math.all(u.math.isfinite(outputs))
+        assert u.math.std(outputs) > 0.05 * u.mV
 
-    def test_demo_seizure_like_activity(self, plot=True):
+    def test_demo_seizure_like_activity(self, plot=False):
         """Demonstrate seizure-like activity with modified parameters."""
         brainstate.environ.set(dt=0.0001 * u.second)  # 0.1 ms
 
@@ -468,7 +476,11 @@ class TestJansenRitModel:
             plt.show()
             plt.close()
 
-        return time, outputs
+        # The high-gain "seizure" parameter set drives a finite but much larger
+        # excursion than the alpha set (full-trajectory std measured at ~4 mV).
+        assert outputs.shape == (n_steps, 1)
+        assert u.math.all(u.math.isfinite(outputs))
+        assert u.math.std(outputs) > 0.5 * u.mV
 
 
 class TestJansenRitTR:
@@ -478,6 +490,7 @@ class TestJansenRitTR:
     def _make(n=3, tr=1e-3 * u.second, dt=1e-4 * u.second, seed=0):
         brainstate.environ.set(dt=dt)
         brainstate.random.seed(seed)
+        np.random.seed(seed)  # sc/delay/w below use numpy's RNG
         sc = jnp.asarray(np.random.rand(n, n))
         sc = sc - jnp.diag(jnp.diag(sc))
         delay = jnp.asarray(np.random.randint(1, 5, size=(n, n)).astype(float))
@@ -541,6 +554,7 @@ class TestJansenRitTRMask:
         n = 3
         brainstate.environ.set(dt=1e-4 * u.second)
         brainstate.random.seed(0)
+        np.random.seed(0)  # sc/delay/w/mask below use numpy's RNG
         sc = jnp.asarray(np.random.rand(n, n))
         sc = sc - jnp.diag(jnp.diag(sc))
         delay = jnp.asarray(np.random.randint(1, 5, size=(n, n)).astype(float))
@@ -558,6 +572,7 @@ class TestJansenRitTRMask:
 
 def _jr_seq(T, n, seed=0):
     brainstate.random.seed(seed)
+    np.random.seed(seed)  # the sequence below uses numpy's RNG, not brainstate's
     return jnp.asarray(np.random.randn(T, n).astype('float32'))
 
 
@@ -575,6 +590,7 @@ class TestJansenRitLayer:
     def test_delayed_path_and_record_state(self):
         from brainmass.jansen_rit import JansenRitLayer
         brainstate.environ.set(dt=1e-4 * u.second)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
         m = JansenRitLayer(n_input=3, n_hidden=5, delay=delay)
         brainstate.nn.init_all_states(m)
@@ -589,6 +605,7 @@ class TestJansenRit2LayerAndNetwork:
     def test_jansen_rit2_layer_record_state(self):
         from brainmass.jansen_rit import JansenRit2Layer
         brainstate.environ.set(dt=1e-4 * u.second)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
         m = JansenRit2Layer(n_input=3, n_hidden=5, delay=delay)
         brainstate.nn.init_all_states(m)
@@ -605,6 +622,7 @@ class TestJansenRit2LayerAndNetwork:
     def test_network_single_and_multi_layer(self):
         from brainmass.jansen_rit import JansenRitNetwork
         brainstate.environ.set(dt=1e-4 * u.second)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
         net = JansenRitNetwork(n_input=3, n_hidden=5, n_output=2, delay=delay)
         brainstate.nn.init_all_states(net)
@@ -623,6 +641,7 @@ class TestJansenRit2LayerAndNetwork:
     def test_network_multi_layer_unit_chaining_bug(self):
         from brainmass.jansen_rit import JansenRitNetwork
         brainstate.environ.set(dt=1e-4 * u.second)
+        np.random.seed(0)  # deterministic delay matrix
         delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype(float)) * u.ms
         net = JansenRitNetwork(n_input=3, n_hidden=[5, 5], n_output=2, delay=delay)
         brainstate.nn.init_all_states(net)

--- a/brainmass/kuramoto_test.py
+++ b/brainmass/kuramoto_test.py
@@ -1,0 +1,184 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for :class:`brainmass.KuramotoNetwork`.
+
+Covers construction, the connectivity variants and their validation, the noise
+path, and -- as a meaningful dynamical oracle -- the Kuramoto order parameter
+:math:`R = |\\langle e^{i\\theta} \\rangle|`, which must approach 1 (full phase
+synchrony) under strong coupling and stay flat with no coupling.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+import brainstate
+import brainunit as u
+from brainstate.nn import Param
+
+import brainmass
+
+
+def _order_parameter(theta):
+    """Kuramoto order parameter ``R = |mean(exp(i*theta))|`` in ``[0, 1]``."""
+    theta = np.asarray(u.get_magnitude(theta))
+    return float(np.abs(np.mean(np.exp(1j * theta))))
+
+
+def _run(model, n_steps, theta_inp=None):
+    """Run ``model`` for ``n_steps`` and return the stacked phase trajectory."""
+    def step(i):
+        with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+            return model.update(theta_inp)
+
+    return brainstate.transform.for_loop(step, np.arange(n_steps))
+
+
+def test_construct_and_init_state(dt):
+    """Default construction allocates a phase state of the requested shape."""
+    model = brainmass.KuramotoNetwork(6)
+    brainstate.nn.init_all_states(model)
+    assert model.theta.value.shape == (6,)
+
+
+def test_update_returns_phase(dt, seeded):
+    """A single update returns the new phase with the state shape."""
+    model = brainmass.KuramotoNetwork(5, omega=0.5, K=1.0)
+    brainstate.nn.init_all_states(model)
+    with brainstate.environ.context(i=0, t=0.0 * u.ms):
+        out = model.update()
+    assert out.shape == (5,)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_strong_coupling_synchronizes(dt, seeded):
+    """Identical oscillators with strong coupling reach full phase synchrony."""
+    model = brainmass.KuramotoNetwork(8, omega=0.0, K=8.0, alpha=0.0)
+    brainstate.nn.init_all_states(model)
+    r_initial = _order_parameter(model.theta.value)
+    theta = _run(model, 2000)
+    r_final = _order_parameter(theta[-1])
+    assert r_final > r_initial
+    assert r_final > 0.95, f"expected near-synchrony, got R={r_final:.3f}"
+
+
+def test_zero_coupling_does_not_synchronize(dt, seeded):
+    """With ``K=0`` (and ``omega=0``) phases are frozen, so coherence is unchanged."""
+    model = brainmass.KuramotoNetwork(8, omega=0.0, K=0.0)
+    brainstate.nn.init_all_states(model)
+    r_initial = _order_parameter(model.theta.value)
+    theta = _run(model, 500)
+    r_final = _order_parameter(theta[-1])
+    assert r_final == pytest.approx(r_initial, abs=1e-5)
+
+
+@pytest.mark.parametrize("exclude_self", [True, False])
+@pytest.mark.parametrize("normalize_by_n", [True, False])
+def test_coupling_flags(dt, seeded, exclude_self, normalize_by_n):
+    """All combinations of ``exclude_self`` / ``normalize_by_n`` run finitely."""
+    model = brainmass.KuramotoNetwork(
+        5, omega=0.1, K=2.0, alpha=0.3,
+        exclude_self=exclude_self, normalize_by_n=normalize_by_n)
+    brainstate.nn.init_all_states(model)
+    theta = _run(model, 50)
+    assert jnp.all(jnp.isfinite(theta))
+
+
+def test_explicit_connectivity_matrix(dt, seeded):
+    """A 2-D weight matrix is accepted and produces finite dynamics."""
+    w = np.ones((4, 4), dtype=np.float32) - np.eye(4, dtype=np.float32)
+    model = brainmass.KuramotoNetwork(4, K=2.0, conn=w)
+    brainstate.nn.init_all_states(model)
+    theta = _run(model, 50)
+    assert theta.shape == (50, 4)
+    assert jnp.all(jnp.isfinite(theta))
+
+
+def test_flattened_connectivity_matrix(dt, seeded):
+    """A flattened ``(N*N,)`` weight vector behaves like its 2-D form."""
+    w = (np.ones((4, 4), dtype=np.float32) - np.eye(4, dtype=np.float32)).reshape(-1)
+    model = brainmass.KuramotoNetwork(4, K=2.0, conn=w)
+    brainstate.nn.init_all_states(model)
+    with brainstate.environ.context(i=0, t=0.0 * u.ms):
+        out = model.update()
+    assert out.shape == (4,)
+
+
+def test_connectivity_validation(dt):
+    """Malformed connectivity raises a clear ``ValueError`` at update time."""
+    # 1-D length not divisible by N.
+    m1 = brainmass.KuramotoNetwork(4, K=1.0, conn=np.ones(5, dtype=np.float32))
+    brainstate.nn.init_all_states(m1)
+    with brainstate.environ.context(i=0, t=0.0 * u.ms):
+        with pytest.raises(ValueError, match="not divisible"):
+            m1.update()
+
+    # 1-D divisible but not square (N_in != N).
+    m2 = brainmass.KuramotoNetwork(4, K=1.0, conn=np.ones(8, dtype=np.float32))
+    brainstate.nn.init_all_states(m2)
+    with brainstate.environ.context(i=0, t=0.0 * u.ms):
+        with pytest.raises(ValueError, match="square"):
+            m2.update()
+
+    # 2-D wrong shape.
+    m3 = brainmass.KuramotoNetwork(4, K=1.0, conn=np.ones((3, 4), dtype=np.float32))
+    brainstate.nn.init_all_states(m3)
+    with brainstate.environ.context(i=0, t=0.0 * u.ms):
+        with pytest.raises(ValueError, match="square"):
+            m3.update()
+
+    # 3-D connectivity.
+    m4 = brainmass.KuramotoNetwork(2, K=1.0, conn=np.ones((2, 2, 2), dtype=np.float32))
+    brainstate.nn.init_all_states(m4)
+    with brainstate.environ.context(i=0, t=0.0 * u.ms):
+        with pytest.raises(ValueError, match="1D flattened or 2D"):
+            m4.update()
+
+
+def test_noise_is_seeded_and_reproducible(dt):
+    """The noise path runs and is reproducible under a fixed seed."""
+    def run_with_noise():
+        brainstate.random.seed(11)
+        noise = brainmass.GaussianNoise(5, sigma=0.2)
+        model = brainmass.KuramotoNetwork(5, omega=0.1, K=1.0, noise_theta=noise)
+        brainstate.nn.init_all_states(model)
+        return np.asarray(u.get_magnitude(_run(model, 30)))
+
+    a = run_with_noise()
+    b = run_with_noise()
+    assert np.array_equal(a, b)
+    assert np.all(np.isfinite(a))
+
+
+def test_invalid_noise_type_raises(dt):
+    """A non-``Noise`` ``noise_theta`` is rejected at construction."""
+    with pytest.raises(AssertionError, match="noise_theta"):
+        brainmass.KuramotoNetwork(4, noise_theta="not-a-noise")
+
+
+def test_gradient_flows_through_coupling(dt):
+    """A gradient flows through the network w.r.t. a trainable coupling ``K``."""
+    def loss(k):
+        brainstate.random.seed(0)
+        model = brainmass.KuramotoNetwork(6, omega=0.2, K=Param(k, fit=True))
+        brainstate.nn.init_all_states(model)
+        theta = _run(model, 40)
+        return jnp.sum(jnp.sin(u.get_magnitude(theta)) ** 2)
+
+    value, grad = jax.value_and_grad(loss)(jnp.asarray(1.5))
+    assert jnp.isfinite(value)
+    assert jnp.isfinite(grad)

--- a/brainmass/leadfield_test.py
+++ b/brainmass/leadfield_test.py
@@ -25,6 +25,7 @@ import brainmass
 
 def _make(normalize=True, demean=True, M=3, N=5, seed=0):
     brainstate.random.seed(seed)
+    np.random.seed(seed)  # the lead-field matrix below uses numpy's RNG
     lm = jnp.asarray(np.random.randn(M, N).astype('float32'))
     readout = brainmass.LeadfieldReadout(
         lm=lm,

--- a/brainmass/noise_test.py
+++ b/brainmass/noise_test.py
@@ -120,6 +120,7 @@ class TestOUProcess:
     def test_statistical_properties_mean_reversion(self):
         """Test that the process shows mean reversion over time"""
         brainstate.environ.set(dt=0.1 * u.ms)
+        brainstate.random.seed(0)  # deterministic so the tolerances below are meaningful
 
         # Start with non-zero initial condition
         noise = brainmass.OUProcess(1, mean=0.0 * u.nA, sigma=0.1 * u.nA, tau=10.0 * u.ms)
@@ -130,17 +131,25 @@ class TestOUProcess:
             with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
                 return noise.update()
 
-        # Run for many steps to observe mean reversion
+        # Run for many steps to observe mean reversion (100 ms = 10 tau).
         xs = brainstate.transform.for_loop(step_run, np.arange(1000))
 
-        # The final values should be closer to mean than initial
-        final_mean = np.mean(xs[-100:])  # Average of last 100 steps
-        assert abs(final_mean) < 4.0 * u.nA, "Process should revert toward mean over time"
+        # The process must revert to near its mean of 0 (started at 5 nA). The old
+        # bound of 4 nA was so loose it would pass even with badly-scaled noise.
+        final_mean = np.mean(xs[-100:])
+        assert abs(final_mean) < 0.5 * u.nA, "Process should revert toward mean over time"
+
+        # The stationary fluctuation scale must match the noise amplitude. A broken
+        # increment (e.g. the historical sqrt(dt) cancellation bug) would shift this
+        # by orders of magnitude.
+        tail_std = float(np.std(xs[-500:].mantissa))
+        assert 0.03 < tail_std < 0.15, f"stationary std {tail_std:.3f} nA is off-scale"
 
     def test_statistical_properties_with_nonzero_mean(self):
         """Test that process converges to specified non-zero mean"""
         brainstate.environ.set(dt=0.1 * u.ms)
 
+        brainstate.random.seed(0)  # deterministic mean estimate
         target_mean = 2.0 * u.nA
         noise = brainmass.OUProcess(1, mean=target_mean, sigma=0.5 * u.nA, tau=5.0 * u.ms)
         noise.init_state()
@@ -152,9 +161,10 @@ class TestOUProcess:
         # Run simulation
         xs = brainstate.transform.for_loop(step_run, np.arange(2000))
 
-        # Check convergence to target mean
-        final_mean = u.math.mean(xs[-200:]).mantissa  # Average of last 200 steps
-        assert abs(final_mean - 2.0) < 0.5, f"Mean should converge to {target_mean}, got {final_mean}"
+        # Check convergence to target mean (averaging the second half for a stable
+        # estimate of the stationary mean).
+        final_mean = u.math.mean(xs[1000:]).mantissa
+        assert abs(final_mean - 2.0) < 0.3, f"Mean should converge to {target_mean}, got {final_mean}"
 
     def test_different_time_steps(self):
         """Test behavior with different time step sizes"""
@@ -189,6 +199,7 @@ class TestOUProcess:
 
     def test_batch_processing_independence(self):
         """Test that batch samples are independent"""
+        brainstate.random.seed(0)
         batch_size = 100
         noise = brainmass.OUProcess(1, sigma=2.0 * u.nA, tau=10.0 * u.ms)
         noise.init_state(batch_size=batch_size)
@@ -217,6 +228,7 @@ class TestOUProcess:
     def test_integration_long_simulation(self):
         """Test stability over long simulation"""
         brainstate.environ.set(dt=0.1 * u.ms)
+        brainstate.random.seed(0)
 
         noise = brainmass.OUProcess(1, mean=1.0 * u.nA, sigma=0.5 * u.nA, tau=20.0 * u.ms)
         noise.init_state()
@@ -228,13 +240,21 @@ class TestOUProcess:
         # Long simulation
         xs = brainstate.transform.for_loop(step_run, np.arange(10000))
 
-        # Check that values remain bounded (shouldn't explode to infinity)
+        # Check that values remain bounded (shouldn't explode to infinity). The old
+        # bound of 50 nA was ~25x the actual excursion; a much tighter bound still
+        # passes the well-behaved process but catches a runaway/explosion.
         assert u.math.all(u.math.isfinite(xs)), "All values should remain finite"
-        assert u.math.max(u.math.abs(xs)) < 50.0 * u.nA, "Values should remain reasonably bounded"
+        assert u.math.max(u.math.abs(xs)) < 5.0 * u.nA, "Values should remain reasonably bounded"
+
+        # The stationary mean/std must match the configured drift and amplitude.
+        assert abs(np.mean(xs[5000:].mantissa) - 1.0) < 0.2, "should fluctuate about mean 1 nA"
+        assert 0.2 < float(np.std(xs[5000:].mantissa)) < 0.7, "stationary std off-scale"
 
 
 class TestNoise:
     def test1(self):
+        """A long OU run stays finite and bounded (no plotting needed)."""
+        brainstate.random.seed(0)
         noise = brainmass.OUProcess(1)
         noise.init_state()
 
@@ -244,10 +264,9 @@ class TestNoise:
             return noise.x.value
 
         xs = brainstate.transform.for_loop(step_run, np.arange(100000))
-        # Remove plotting for automated testing
-        # plt.plot(xs)
-        # plt.show()
-        # plt.close()
+        assert u.math.all(u.math.isfinite(xs)), "OU process should remain finite"
+        # Default sigma=1 nA, tau=10 ms: excursions stay well within ~10 nA.
+        assert u.math.max(u.math.abs(xs)) < 10.0 * u.nA
 
 
 class TestGaussianAndWhiteNoise:

--- a/brainmass/wilson_cowan_test.py
+++ b/brainmass/wilson_cowan_test.py
@@ -386,26 +386,25 @@ class TestWilsonCowanModel:
 
         assert result.shape == (3,)
 
-    # def test_stability_long_simulation(self):
-    #     """Test stability over long simulation"""
-    #     brainstate.environ.set(dt=0.1 * u.ms)
-    #
-    #     model = brainmass.WilsonCowanStep(1)
-    #     model.init_state()
-    #
-    #     def step_run(i):
-    #         with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
-    #             return model.update(rE_inp=2.0, rI_inp=1.0)
-    #
-    #     # Long simulation
-    #     n_steps = 10000
-    #     results = brainstate.transform.for_loop(step_run, np.arange(n_steps))
-    #
-    #     # Check that values remain bounded
-    #     assert u.math.all(u.math.isfinite(results)), "All values should remain finite"
-    #     max_val = u.math.max(u.math.abs(results)).mantissa if hasattr(u.math.max(u.math.abs(results)),
-    #                                                                   'mantissa') else u.math.max(u.math.abs(results))
-    #     assert max_val < 100.0, "Values should remain reasonably bounded"
+    def test_stability_long_simulation(self):
+        """Test stability over long simulation"""
+        brainstate.environ.set(dt=0.1 * u.ms)
+
+        model = brainmass.WilsonCowanStep(1)
+        model.init_state()
+
+        def step_run(i):
+            with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+                return model.update(rE_inp=2.0, rI_inp=1.0)
+
+        # Long simulation
+        n_steps = 10000
+        results = brainstate.transform.for_loop(step_run, np.arange(n_steps))
+
+        # Check that values remain bounded (this parameter set settles near 0.49).
+        assert u.math.all(u.math.isfinite(results)), "All values should remain finite"
+        max_val = u.get_magnitude(u.math.max(u.math.abs(results)))
+        assert max_val < 100.0, "Values should remain reasonably bounded"
 
     def test_excitation_inhibition_balance(self):
         """Test excitation-inhibition balance affects dynamics"""
@@ -630,17 +629,20 @@ class TestWilsonCowanNoSaturation:
         # State should have changed
         assert not jnp.allclose(model.rE.value, initial_rE)
 
-    # def test_stability_long_simulation(self):
-    #     """Test stability over long simulation (10000 steps)"""
-    #     brainstate.environ.set(dt=0.1 * u.ms)
-    #     model = brainmass.WilsonCowanNoSaturationStep(1)
-    #     model.init_state()
-    #     for i in range(10000):
-    #         with brainstate.environ.context(i=i, t=i * 0.1 * u.ms):
-    #             output = model.update(rE_inp=0.1)
-    #         # Check for explosions or NaN
-    #         assert jnp.isfinite(output).all()
-    #         assert jnp.all(output < 100.)  # Reasonable bound
+    def test_stability_long_simulation(self):
+        """Test stability over long simulation (10000 steps)"""
+        brainstate.environ.set(dt=0.1 * u.ms)
+        model = brainmass.WilsonCowanNoSaturationStep(1)
+        model.init_state()
+
+        def step_run(i):
+            with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+                return model.update(rE_inp=0.1)
+
+        outputs = brainstate.transform.for_loop(step_run, np.arange(10000))
+        # Check for explosions or NaN over the whole trajectory.
+        assert jnp.isfinite(outputs).all()
+        assert jnp.all(outputs < 100.)  # Reasonable bound
 
 
 class TestWilsonCowanSymmetric:
@@ -719,16 +721,19 @@ class TestWilsonCowanSymmetric:
             output = model.update(rE_inp=0.1)
         assert output.shape == (5,)
 
-    # def test_stability_long_simulation(self):
-    #     """Test stability over long simulation"""
-    #     brainstate.environ.set(dt=0.1 * u.ms)
-    #     model = brainmass.WilsonCowanSymmetricStep(1)
-    #     model.init_state()
-    #     for i in range(10000):
-    #         with brainstate.environ.context(i=i, t=i * 0.1 * u.ms):
-    #             output = model.update(rE_inp=0.1)
-    #         assert jnp.isfinite(output).all()
-    #         assert jnp.all(output < 100.)
+    def test_stability_long_simulation(self):
+        """Test stability over long simulation"""
+        brainstate.environ.set(dt=0.1 * u.ms)
+        model = brainmass.WilsonCowanSymmetricStep(1)
+        model.init_state()
+
+        def step_run(i):
+            with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+                return model.update(rE_inp=0.1)
+
+        outputs = brainstate.transform.for_loop(step_run, np.arange(10000))
+        assert jnp.isfinite(outputs).all()
+        assert jnp.all(outputs < 100.)
 
 
 class TestWilsonCowanSimplified:
@@ -807,16 +812,19 @@ class TestWilsonCowanSimplified:
             output = model.update(rE_inp=0.1)
         assert output.shape == (5,)
 
-    # def test_stability_long_simulation(self):
-    #     """Test stability over long simulation"""
-    #     brainstate.environ.set(dt=0.1 * u.ms)
-    #     model = brainmass.WilsonCowanSimplifiedStep(1)
-    #     model.init_state()
-    #     for i in range(10000):
-    #         with brainstate.environ.context(i=i, t=i * 0.1 * u.ms):
-    #             output = model.update(rE_inp=0.1)
-    #         assert jnp.isfinite(output).all()
-    #         assert jnp.all(output < 100.)
+    def test_stability_long_simulation(self):
+        """Test stability over long simulation"""
+        brainstate.environ.set(dt=0.1 * u.ms)
+        model = brainmass.WilsonCowanSimplifiedStep(1)
+        model.init_state()
+
+        def step_run(i):
+            with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+                return model.update(rE_inp=0.1)
+
+        outputs = brainstate.transform.for_loop(step_run, np.arange(10000))
+        assert jnp.isfinite(outputs).all()
+        assert jnp.all(outputs < 100.)
 
 
 class TestWilsonCowanLinear:
@@ -902,13 +910,16 @@ class TestWilsonCowanLinear:
             output = model.update(rE_inp=0.1)
         assert output.shape == (5,)
 
-    # def test_stability_long_simulation(self):
-    #     """Test stability over long simulation"""
-    #     brainstate.environ.set(dt=0.1 * u.ms)
-    #     model = brainmass.WilsonCowanLinearStep(1)
-    #     model.init_state()
-    #     for i in range(10000):
-    #         with brainstate.environ.context(i=i, t=i * 0.1 * u.ms):
-    #             output = model.update(rE_inp=0.1)
-    #         assert jnp.isfinite(output).all()
-    #         assert jnp.all(output < 100.)
+    def test_stability_long_simulation(self):
+        """Test stability over long simulation"""
+        brainstate.environ.set(dt=0.1 * u.ms)
+        model = brainmass.WilsonCowanLinearStep(1)
+        model.init_state()
+
+        def step_run(i):
+            with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+                return model.update(rE_inp=0.1)
+
+        outputs = brainstate.transform.for_loop(step_run, np.arange(10000))
+        assert jnp.isfinite(outputs).all()
+        assert jnp.all(outputs < 100.)

--- a/brainmass/wilson_cowan_variants_test.py
+++ b/brainmass/wilson_cowan_variants_test.py
@@ -1,0 +1,208 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Coverage + behaviour tests for the less-common Wilson-Cowan variants.
+
+The base :class:`brainmass.WilsonCowanStep` and a few simple variants were tested
+already; this module covers the previously-untested variants -- divisive,
+divisive-input, delayed, adaptive and three-population -- plus the sequence
+network components (``WilsonCowanSeqLayer`` / ``WilsonCowanSeqNetwork``).
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+import brainstate
+import brainunit as u
+from brainstate.nn import Param
+
+import brainmass
+from brainmass import wilson_cowan as wc
+
+
+def _run(model, n_steps, **inp):
+    """Advance ``model`` for ``n_steps`` and return the stacked output trajectory."""
+    def step(i):
+        with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+            return model.update(**inp)
+
+    return brainstate.transform.for_loop(step, np.arange(n_steps))
+
+
+# All single-node Wilson-Cowan step variants that were previously untested.
+STEP_VARIANTS = {
+    "divisive": brainmass.WilsonCowanDivisiveStep,
+    "divisive_input": brainmass.WilsonCowanDivisiveInputStep,
+    "delayed": brainmass.WilsonCowanDelayedStep,
+    "adaptive": brainmass.WilsonCowanAdaptiveStep,
+    "threepop": brainmass.WilsonCowanThreePopulationStep,
+}
+
+
+@pytest.mark.parametrize("name", list(STEP_VARIANTS))
+def test_variant_simulates_finitely(name, dt):
+    """Each variant constructs, initialises and integrates to a finite trajectory."""
+    model = STEP_VARIANTS[name](2)
+    brainstate.nn.init_all_states(model)
+    out = _run(model, 100, rE_inp=0.5)
+    assert out.shape == (100, 2)
+    assert jnp.all(jnp.isfinite(out))
+
+
+@pytest.mark.parametrize("name", list(STEP_VARIANTS))
+def test_variant_rk4_integration(name, dt):
+    """Each variant integrates finitely under a higher-order solver (rk4 path).
+
+    This exercises every variant's ``derivative`` aggregator (used only by the
+    non-``exp_euler`` branch), which the default-method tests never reach.
+    """
+    model = STEP_VARIANTS[name](2, method="rk4")
+    brainstate.nn.init_all_states(model)
+    out = _run(model, 50, rE_inp=0.5)
+    assert out.shape == (50, 2)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_divisive_semisaturation_keeps_output_bounded(dt):
+    """Divisive normalisation with positive semisaturation stays finite/bounded."""
+    model = brainmass.WilsonCowanDivisiveStep(1, sigma_E=1.0, sigma_I=1.0)
+    brainstate.nn.init_all_states(model)
+    out = _run(model, 200, rE_inp=2.0)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_adaptive_has_four_states_and_suppresses_activity(dt):
+    """Adaptive variant tracks adaptation currents and damps sustained activity."""
+    model = brainmass.WilsonCowanAdaptiveStep(1, b_E=0.5, tau_aE=20.0 * u.ms)
+    brainstate.nn.init_all_states(model)
+    # Four state variables: rE, rI, aE, aI.
+    states = model.states(brainstate.HiddenState)
+    names = {k[-1] if isinstance(k, tuple) else k for k in states.keys()}
+    assert {"rE", "rI", "aE", "aI"} <= names
+
+    out = np.asarray(u.get_magnitude(_run(model, 2000, rE_inp=3.0)))
+    early_peak = out[:200].max()
+    late = out[-200:].mean()
+    assert late < early_peak, "adaptation should reduce activity over time"
+
+
+def test_adaptive_adaptation_derivatives(dt):
+    """The adaptation derivative helpers return finite ``1/ms`` rates."""
+    model = brainmass.WilsonCowanAdaptiveStep(3)
+    brainstate.nn.init_all_states(model)
+    daE = model.daE(model.aE.value, model.rE.value)
+    daI = model.daI(model.aI.value, model.rI.value)
+    assert u.get_unit(daE) == u.get_unit(1.0 / u.ms)
+    assert jnp.all(jnp.isfinite(u.get_magnitude(daE)))
+    assert jnp.all(jnp.isfinite(u.get_magnitude(daI)))
+
+
+def test_threepopulation_has_modulatory_state(dt):
+    """The three-population variant adds a modulatory state ``rM`` and ``drM``."""
+    model = brainmass.WilsonCowanThreePopulationStep(2)
+    brainstate.nn.init_all_states(model)
+    states = model.states(brainstate.HiddenState)
+    names = {k[-1] if isinstance(k, tuple) else k for k in states.keys()}
+    assert {"rE", "rI", "rM"} <= names
+    drM = model.drM(model.rM.value, model.rE.value, model.rI.value, 0.0)
+    assert jnp.all(jnp.isfinite(u.get_magnitude(drM)))
+    out = _run(model, 100, rE_inp=1.0, rI_inp=0.5, rM_inp=0.2)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_threepop_base_is_abstract(dt):
+    """``WilsonCowanThreePopBase`` is abstract: its RHS methods are unimplemented."""
+    base = wc.WilsonCowanThreePopBase(2)
+    brainstate.nn.init_all_states(base)
+    with pytest.raises(NotImplementedError):
+        with brainstate.environ.context(i=0, t=0.0 * u.ms):
+            base.update(0.5)
+
+
+def test_variant_gradient_flows(dt):
+    """A gradient flows through a divisive variant w.r.t. a trainable weight."""
+    def loss(w):
+        brainstate.random.seed(0)
+        model = brainmass.WilsonCowanDivisiveStep(2, wEE=Param(w, fit=True))
+        brainstate.nn.init_all_states(model)
+        out = _run(model, 40, rE_inp=1.0)
+        return jnp.sum(u.get_magnitude(out) ** 2)
+
+    value, grad = jax.value_and_grad(loss)(jnp.asarray(6.0))
+    assert jnp.isfinite(value) and jnp.isfinite(grad)
+
+
+# --------------------------------------------------------------------------- #
+# Sequence network components
+# --------------------------------------------------------------------------- #
+
+def _seq(n_steps, n_features, seed=0):
+    """Deterministic ``(n_steps, n_features)`` input sequence (seeds numpy's RNG)."""
+    brainstate.random.seed(seed)
+    np.random.seed(seed)  # the sequence below uses numpy's RNG, not brainstate's
+    return jnp.asarray(np.random.randn(n_steps, n_features).astype("float32"))
+
+
+def test_seq_layer_processes_sequence(dt):
+    """``WilsonCowanSeqLayer`` maps a ``(T, n_input)`` sequence to ``(T, n_hidden)``."""
+    layer = wc.WilsonCowanSeqLayer(3, 5)
+    brainstate.nn.init_all_states(layer)
+    out = layer.update(_seq(10, 3))
+    assert out.shape == (10, 5)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_seq_layer_record_state(dt):
+    """``record_state=True`` returns the per-step internal states alongside output."""
+    layer = wc.WilsonCowanSeqLayer(3, 5)
+    brainstate.nn.init_all_states(layer)
+    result = layer.update(_seq(8, 3), record_state=True)
+    assert isinstance(result, tuple) and len(result) == 2
+
+
+def test_seq_layer_with_delay(dt):
+    """The delayed recurrent path (``DelayedAdditiveConn``) runs over a sequence."""
+    brainstate.random.seed(0)
+    np.random.seed(0)  # deterministic delay matrix (numpy's RNG)
+    delay = jnp.asarray(np.random.randint(1, 4, size=(5, 5)).astype("float32")) * u.ms
+    layer = wc.WilsonCowanSeqLayer(3, 5, delay=delay)
+    brainstate.nn.init_all_states(layer)
+    out = layer.update(_seq(30, 3))
+    assert out.shape == (30, 5)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_seq_network_single_layer(dt):
+    """``WilsonCowanSeqNetwork`` reduces a sequence to an ``(n_output,)`` readout."""
+    net = wc.WilsonCowanSeqNetwork(4, 6, 2)
+    brainstate.nn.init_all_states(net)
+    out = net.update(_seq(12, 4))
+    assert out.shape == (2,)
+    assert jnp.all(jnp.isfinite(out))
+
+
+def test_seq_network_multi_layer_and_hidden_activation(dt):
+    """A multi-layer network stacks layers and exposes per-layer activations."""
+    net = wc.WilsonCowanSeqNetwork(4, [6, 8], 3)
+    brainstate.nn.init_all_states(net)
+    inp = _seq(12, 4)
+    out = net.update(inp)
+    assert out.shape == (3,)
+    hidden = net.hidden_activation(inp)
+    assert isinstance(hidden, list) and len(hidden) == 2
+    assert hidden[0].shape == (12, 6)
+    assert hidden[1].shape == (12, 8)

--- a/brainmass/wong_wang_test.py
+++ b/brainmass/wong_wang_test.py
@@ -22,6 +22,36 @@ import numpy as np
 import brainmass
 
 
+def _assert_decision_traces(n_steps, r1_trace, r2_trace, S1_trace, S2_trace):
+    """Shared assertions for the Wong-Wang decision-making demo trajectories.
+
+    Each demo seeds the RNG and integrates the two-population decision network.
+    A valid run must (a) stay finite, (b) keep the synaptic gating variables in
+    their physical ``[0, 1]`` range, and (c) actually accumulate evidence -- the
+    gating must rise meaningfully above its zero initial condition rather than
+    staying flat, confirming the decision dynamics ran.
+    """
+    for trace in (r1_trace, r2_trace, S1_trace, S2_trace):
+        assert trace.shape == (n_steps, 1)
+        assert u.math.all(u.math.isfinite(trace))
+
+    # Firing rates are non-negative.
+    assert u.math.all(u.get_magnitude(r1_trace) >= 0.0)
+    assert u.math.all(u.get_magnitude(r2_trace) >= 0.0)
+
+    # Synaptic gating stays within [0, 1] (allow a tiny float tolerance).
+    for S in (S1_trace, S2_trace):
+        Sm = u.get_magnitude(S)
+        assert u.math.all(Sm >= -1e-6) and u.math.all(Sm <= 1.0 + 1e-6)
+
+    # Evidence accumulated: at least one population's gating climbed clear of 0.
+    peak_gating = max(
+        float(u.math.max(u.get_magnitude(S1_trace))),
+        float(u.math.max(u.get_magnitude(S2_trace))),
+    )
+    assert peak_gating > 0.1, "decision dynamics did not accumulate evidence"
+
+
 class TestWongWangModel:
 
     def test_initialization(self):
@@ -275,9 +305,10 @@ class TestWongWangModel:
         print("=" * 40)
         print("All WongWangStep tests passed! ✓")
 
-    def test_demo_decision_making(self, plot=True):
+    def test_demo_decision_making(self, plot=False):
         """Demonstrate decision-making behavior."""
         brainstate.environ.set(dt=0.0001 * u.second)
+        brainstate.random.seed(0)  # decision dynamics are noise-driven
 
         model = brainmass.WongWangStep(in_size=1)
         model.init_state()
@@ -319,11 +350,12 @@ class TestWongWangModel:
             plt.show()
             plt.close()
 
-        return time, r1_trace, r2_trace, S1_trace, S2_trace
+        _assert_decision_traces(n_steps, r1_trace, r2_trace, S1_trace, S2_trace)
 
-    def test_demo_decision_making_ms(self, plot=True):
+    def test_demo_decision_making_ms(self, plot=False):
         """Demonstrate decision-making behavior."""
         brainstate.environ.set(dt=0.1 * u.ms)
+        brainstate.random.seed(0)  # decision dynamics are noise-driven
 
         model = brainmass.WongWangStep(in_size=1, tau_S=100. * u.ms)
         model.init_state()
@@ -365,9 +397,12 @@ class TestWongWangModel:
             plt.show()
             plt.close()
 
-    def test_demo_decision_making_ms_v3(self, plot=True):
+        _assert_decision_traces(n_steps, r1_trace, r2_trace, S1_trace, S2_trace)
+
+    def test_demo_decision_making_ms_v3(self, plot=False):
         """Demonstrate decision-making behavior."""
         brainstate.environ.set(dt=0.1 * u.ms)
+        brainstate.random.seed(0)  # decision dynamics are noise-driven
 
         model = brainmass.WongWangStep(in_size=1, tau_S=0.1 * u.second)
         model.init_state()
@@ -408,3 +443,5 @@ class TestWongWangModel:
             plt.tight_layout()
             plt.show()
             plt.close()
+
+        _assert_decision_traces(n_steps, r1_trace, r2_trace, S1_trace, S2_trace)

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,26 @@
-"""Pytest configuration for the brainmass test suite.
+"""Pytest configuration and shared fixtures for the brainmass test suite.
 
 Forces matplotlib onto the non-interactive ``Agg`` backend so the demo tests
 (``test_demo_*``, which default to ``plot=True`` and call ``plt.show()``) never
 open a blocking GUI window. Under ``Agg`` the ``plt.show()`` call is a
 non-blocking no-op, so ``pytest brainmass/`` runs unattended in CI and headless
 shells instead of hanging until each figure window is closed by hand.
+
+Also provides reusable fixtures (goal-04 testing rigor):
+
+``_isolate_environ_dt``
+    Autouse. Snapshots and restores the global ``brainstate.environ`` ``dt`` so a
+    test that calls ``environ.set(dt=...)`` cannot leak its time step into later,
+    unrelated tests.
+``dt``
+    Sets a known integration time step for the duration of a test (parametrizable
+    via ``indirect=True``) and yields it.
+``seeded``
+    Seeds ``brainstate.random`` and ``numpy.random`` for deterministic stochastic
+    tests (parametrizable via ``indirect=True``) and yields the seed.
+``connectome``
+    A small structural-connectivity (``SC``) + distance/delay fixture for
+    whole-brain coupling tests.
 """
 
 import matplotlib
@@ -15,7 +31,19 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402  (import after backend selection)
-import pytest
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+import brainstate  # noqa: E402
+import brainunit as u  # noqa: E402
+
+#: Default integration time step used by the ``dt`` fixture.
+DEFAULT_DT = 0.1 * u.ms
+
+#: Default RNG seed used by the ``seeded`` fixture.
+DEFAULT_SEED = 0
+
+_UNSET = object()
 
 
 @pytest.fixture(autouse=True)
@@ -28,3 +56,132 @@ def _close_matplotlib_figures():
     """
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_environ_dt():
+    """Prevent the global ``environ`` time step from leaking across tests.
+
+    Many tests call ``brainstate.environ.set(dt=...)`` at module or function
+    scope. Because ``environ`` is process-global, a value set by one test would
+    otherwise persist and silently change the behaviour of a later test that
+    forgot to set its own ``dt``. This autouse fixture snapshots ``dt`` before
+    the test and restores (or removes) it afterwards.
+    """
+    prev = brainstate.environ.get("dt", _UNSET)
+    try:
+        yield
+    finally:
+        if prev is _UNSET:
+            # ``dt`` was unset before the test; drop anything the test set.
+            brainstate.environ.pop("dt", None)
+        else:
+            brainstate.environ.set(dt=prev)
+
+
+@pytest.fixture
+def dt(request):
+    """Set a known integration time step for the test and yield it.
+
+    Parameters
+    ----------
+    request : pytest.FixtureRequest
+        If parametrized with ``indirect=True``, ``request.param`` supplies the
+        time step (a ``brainunit`` quantity with time units). Otherwise
+        :data:`DEFAULT_DT` is used.
+
+    Yields
+    ------
+    brainunit.Quantity
+        The time step that was installed into ``brainstate.environ``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> def test_uses_default_dt(dt):
+        ...     assert dt is not None
+    """
+    value = getattr(request, "param", DEFAULT_DT)
+    brainstate.environ.set(dt=value)
+    yield value
+    # Cleanup is handled by ``_isolate_environ_dt``.
+
+
+@pytest.fixture
+def seeded(request):
+    """Seed the global RNGs for a deterministic stochastic test.
+
+    Seeds both ``brainstate.random`` (the JAX-backed RNG used by the noise
+    processes and initializers) and ``numpy.random`` (used by a few tests to
+    build random connectivity).
+
+    Parameters
+    ----------
+    request : pytest.FixtureRequest
+        If parametrized with ``indirect=True``, ``request.param`` supplies the
+        integer seed. Otherwise :data:`DEFAULT_SEED` is used.
+
+    Yields
+    ------
+    int
+        The seed that was applied.
+    """
+    seed = int(getattr(request, "param", DEFAULT_SEED))
+    brainstate.random.seed(seed)
+    np.random.seed(seed)
+    yield seed
+
+
+@pytest.fixture
+def connectome():
+    """Provide a small, deterministic connectome for coupling tests.
+
+    Returns
+    -------
+    dict
+        Dictionary with keys:
+
+        ``n``
+            Number of regions (``int``).
+        ``SC``
+            ``(n, n)`` non-negative structural-connectivity matrix with a zero
+            diagonal, row-normalised so each row sums to one (``jax.Array``).
+        ``dist``
+            ``(n, n)`` symmetric inter-region distance matrix with a zero
+            diagonal (``jax.Array``).
+        ``delay``
+            ``(n, n)`` conduction delay matrix (``dist`` scaled to milliseconds,
+            a ``brainunit`` quantity).
+
+    Notes
+    -----
+    Values are fixed (not random) so tests built on them are reproducible
+    without needing a seed.
+    """
+    n = 4
+    sc = np.array(
+        [
+            [0.0, 0.8, 0.2, 0.1],
+            [0.8, 0.0, 0.5, 0.3],
+            [0.2, 0.5, 0.0, 0.6],
+            [0.1, 0.3, 0.6, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    sc = sc / sc.sum(axis=1, keepdims=True)  # row-normalise
+    dist = np.array(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [1.0, 0.0, 1.5, 2.0],
+            [2.0, 1.5, 0.0, 1.0],
+            [3.0, 2.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    return {
+        "n": n,
+        "SC": u.math.asarray(sc),
+        "dist": u.math.asarray(dist),
+        "delay": u.math.asarray(dist) * u.ms,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,19 @@ tpu = [
 
 [tool.setuptools.dynamic]
 version = { attr = "brainmass._version.__version__" }
+
+
+[tool.coverage.run]
+branch = true
+source = ["brainmass"]
+omit = [
+    "*_test.py",
+    "*/conftest.py",
+    "*/_version.py",
+]
+
+[tool.coverage.report]
+# CI fails if total coverage drops below this gate (goal-04 testing rigor).
+fail_under = 90
+show_missing = true
+precision = 2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,7 @@
 
 # test requirements
 pytest
+pytest-cov
+coverage
 absl-py
 matplotlib


### PR DESCRIPTION
## Summary

Installs the testing-rigor safety net the suite was missing: differentiability tests (the headline gap — **zero existed**), determinism via seeding, integrator sweeps, and a >90% coverage gate enforced in CI.

**Suite: 229 → 311 passed (+3 xfail). Coverage: 77% → 97.85%, every module ≥ 91.8%.**

## What changed

**Gradients / differentiability** (`gradient_test.py`, new)
- AD flows through a `for_loop` simulation w.r.t. a trainable `Param` for **Hopf, WilsonCowan, JansenRit, MontbrioPazoRoxin, FitzHughNagumo**.
- Per model: `grad`/`value_and_grad`, AD-vs-finite-difference, `jax.test_util.check_grads`, vmap-batched grads, zero-noise-limit recovery, and determinism-under-seeding.

**Integrators** (`integrator_test.py`, new)
- `{exp_euler, rk2, rk4} × model` sweep: finiteness, `exp_euler` proven **exact** on linear decay (analytic oracle), and convergence-order bands (exp_euler≈1, rk2≈2).
- Surfaces a latent bug: `qif.py`'s non-`exp_euler` branch omits `self.derivative` → parked as **2 strict `xfail`s** that flip to pass once goal-05 fixes the model.

**Coverage** (`kuramoto_test.py`, `wilson_cowan_variants_test.py`, `branch_coverage_test.py`, new)
- Cover kuramoto, the divisive / delayed / adaptive / three-population WC variants, the `_xy_model` abstract RHS, noise/fhn branch paths, and deprecated aliases.

**Determinism**
- Seed **both** `brainstate.random` and `numpy.random` everywhere — helpers seeded only the former, leaving numpy-generated connectivity/sequences uncontrolled. Tightened loose noise tolerances that masked broken noise.

**Fixtures** (`conftest.py`, extended not replaced)
- Autouse `_isolate_environ_dt` snapshots/restores global `environ['dt']` (fixes a **real leak** — one Jansen test was passing only on a dt leaked from an earlier test).
- Added `dt` / `seeded` / `connectome` fixtures (all `indirect=`-parametrizable); force matplotlib `Agg`.

**Dead tests repaired**
- Uncommented the 5 WC `test_stability_long_simulation` (converted slow 10k-step python loops → jitted `for_loop`).
- Gave the Jansen / Wong-Wang `plot=True` demos real finiteness/transient/bounded-gating assertions instead of bare `return`; flipped them to `plot=False` default and seeded Wong-Wang.
- Replaced a wrong commented Jansen assertion (`out[-1] >= out[0]`; the output is non-monotonic) with a responsiveness check.

**CI coverage gate**
- `pyproject.toml [tool.coverage]` `fail_under=90`, branch coverage, `omit *_test.py`.
- CI Linux job: `pytest brainmass/ --cov=brainmass --cov-report=term-missing --cov-fail-under=90`; macOS/Windows stay plain. Added `pytest-cov` + `coverage` to `requirements-dev.txt`.

## Notes
- The goal-01 drvfs coverage-SIGABRT did **not** recur — full suite under plain `pytest --cov` ran clean (EXIT=0), so no workaround is shipped.
- Out of scope (goal-05): fixing the `qif.py` integrator bug and other model-code repairs.