### PR TITLE
feat: orchestration layer — Simulator driver + composable objectives (goal-06)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -282,3 +282,61 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
 - **Gotcha confirmed again:** drvfs file-tool persistence is bumpy — `git rm` on a worktree-modified
   file needs `-f`; and a package dir shadows a same-named stale `.py` at import time, so delete the
   old module *before* trusting the smoke test.
+
+### 2026-06-18 · goal-06 orchestration-simulator
+- **Headline — the in-package run loop now exists.** New `brainmass/simulator.py::Simulator` (100%
+  cov) and `brainmass/objectives.py` (100% cov) are the first orchestration layer (sub-project A1,
+  06→07→08). Both exported from `__init__` under a `# Orchestration layer` block (`Simulator` as a
+  class, `objectives` as a submodule). Suite **337→384 passed** (+47: 27 simulator + 20 objectives),
+  coverage **98.17%→98.42%**. No model API touched — the layer is purely additive.
+- **`Simulator(model, dt=None).run(duration, *, inputs, monitors, transient, sample_every,
+  batch_size, init_states, jit)` → plain `dict`** of `{monitor_name: stacked_traj, 'ts': time_axis}`.
+  It only *composes* the existing idiom (`environ.context(dt=)` → `init_all_states` →
+  `for_loop(step_run, arange(n))` → collect `.value`); reimplements nothing. Returns a dict (not a
+  Bunch) so it's a clean pytree through jit/grad/vmap. `sim.model` stays exposed.
+- **Ordering that matters inside `run` (cost us 16 failures, then fixed):** `dt` must be live in
+  `environ` *before* `init_all_states` because delay buffers size from `delay/dt` at init. BUT the
+  `monitors` validation (`hasattr(model, name)`) must run *after* init — state attrs like `x`/`V`
+  don't exist until `init_state`. So: resolve dt/steps/transient/sample_every and build `get_inputs`
+  (input-length check, dt-independent) BEFORE the `environ.context(dt=dt)` block; do `init_all_states`
+  then `_build_measure` INSIDE it. 07/08 closures that drive `.run` must respect this if they
+  pre-validate monitors.
+- **`monitors` polymorphism:** `None`→`{'output': update_return}`; `list[str]`→`getattr(model,name).value`
+  each; `callable(model)`→`{'output': fn(model)}` (derived observables like `lambda m: m.eeg()`);
+  `dict{name: str|callable}`. **`transient`** accepts a `Quantity` *or* an int step count;
+  **`sample_every=k`** is a post-hoc stride `[n_tr::k]` (NOT a substep loop — `for_loop` materialises
+  the whole trajectory anyway, so slicing is exact and ~free) and generalises the `JansenRitTR` TR
+  loop. **`ts` convention:** `ts[k]` = time at the *end* of the k-th recorded step (state is
+  post-`update`), i.e. `((arange(n_steps)+1)*dt)[n_tr::k]` → `ts[0]==dt`, `ts[-1]==duration`.
+- **array `inputs` must be jnp, not numpy** — `arr[i]` with a traced loop counter `i` fails on a
+  numpy array. Cast with `jnp.asarray` *unless* it's a `u.Quantity` (leave Quantities alone; casting
+  drops units). Then `get_inputs(i,t) = (arr[i],)`.
+- **Edge cases pinned (simulator_test.py, 27 tests):** dt unset→ValueError; non-integer
+  `duration/dt`→floor+`warnings.warn`; zero/negative duration→raise; `transient>=duration`→raise;
+  bad monitor name→raise (list *and* dict forms); wrong `inputs` length→raise; `sample_every<1`→raise.
+  Behavioural proofs: single-node run **bit-identical** to a hand-written `for_loop` (seeded,
+  `np.array_equal`); jit vs no-jit identical; units propagate (Montbrio `r`→Hz); `batch_size=4`→leading
+  batch axis `(T,4,N)`; `init_states=False` continues from current state; **`jax.grad` through
+  `run` ≈ FD** (rel 2e-2); whole-brain WilsonCowan+DiffusiveCoupling net matches a manual loop.
+- **`objectives.py` = builders, not metrics.** Each fn returns a small `callable(pred, target)` that's
+  jit/grad/vmap-safe and unit-aware, wrapping `braintools.metric` with zero re-implemented maths:
+  `timeseries_rmse` (unit-CHECKED subtraction — mV vs Hz raises), `fc_corr(as_loss=)`,
+  `fc_rmse`, `cosine_sim(as_loss=, epsilon=)`, `fcd(window_size=, step_size=, as_loss=)`, and
+  `combine(*(weight, objective))`→weighted sum. **`fcd` finally surfaces
+  `functional_connectivity_dynamics`** (was zero call sites — the long-flagged debt). `as_loss=True`
+  returns `1-score` (minimise); default returns the raw score (maximise). `_mag = u.get_magnitude`
+  strips units only where the metric is scale-invariant (FC/cosine), never on the RMSE subtraction.
+  This is the loss surface the goal-08 fitter will minimise; goal-07 (connectome `Network`) feeds
+  its trajectory straight into `Simulator.run` → `objectives.*`.
+- **Doctest gate decision (carrying goal-02's lesson forward):** wrote all examples as **bare `>>>`
+  napoleon blocks**, NOT `.. code-block:: python`. Only bare blocks (+`.. testcode::`) are executed
+  by `sphinx.ext.doctest` (`doctest_test_doctest_blocks="default"`); a `code-block` with `>>>` is
+  cosmetic and silently untested. CLAUDE.md asks for `.. code-block::` styling but the goal-02 ledger
+  + the live doctest gate win here — examples that aren't gated rot. `combine`'s example uses two
+  RMSE terms `(2.0+0.5)*1.0=2.5`, NOT an FC term: FC of an all-zeros (zero-variance) signal is `nan`.
+- **Example migrated:** `examples/000-getting-started.ipynb` Step 5 now uses
+  `brainmass.Simulator(node, dt).run(n_steps*dt, monitors=['x','y'], init_states=False)` instead of a
+  hand-written `step_run`/`for_loop` — bit-identical trajectory (verified). Kept `n_steps`/`indices`
+  defined in that cell because the downstream `visualization` cell and the `simulate_hope_model`
+  exploration cell read the **global** `indices`/`t_ms`; dropping them would break later cells.
+  (Notebooks are `nb_execution_mode="off"` — not run in CI — so verified the equivalence in a script.)

--- a/brainmass/__init__.py
+++ b/brainmass/__init__.py
@@ -96,6 +96,9 @@ from .wilson_cowan import (
     WilsonCowanThreePopulationStep,
 )
 from .wong_wang import WongWangStep
+# Orchestration layer
+from . import objectives
+from .simulator import Simulator
 
 __all__ = [
     '__version__',
@@ -169,6 +172,10 @@ __all__ = [
     'HORNStep',
     'HORNSeqLayer',
     'HORNSeqNetwork',
+
+    # Orchestration layer
+    'Simulator',
+    'objectives',
 ]
 
 

--- a/brainmass/objectives.py
+++ b/brainmass/objectives.py
@@ -1,0 +1,247 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Composable objective (loss / score) builders over simulated trajectories.
+
+Each function here is a *builder*: it takes configuration and returns a small
+``callable(prediction, target)`` that is jit / grad / vmap-safe and unit-aware.
+The callables are thin wrappers over :mod:`braintools.metric` -- they reimplement
+no metric maths -- and are meant to be composed (see :func:`combine`) into the
+loss a fitter (goal-08) minimises.
+
+A *prediction* / *target* is a region time-series array shaped ``(time, regions)``
+(the natural output of :meth:`brainmass.Simulator.run`). Functional-connectivity
+objectives are scale-invariant and operate on magnitudes; the time-series RMSE is
+unit-checked (subtracting incompatible units raises).
+"""
+
+import braintools
+import brainunit as u
+import jax.numpy as jnp
+
+__all__ = [
+    'timeseries_rmse',
+    'fc_corr',
+    'fc_rmse',
+    'cosine_sim',
+    'fcd',
+    'combine',
+]
+
+
+def _mag(x):
+    """Return the bare magnitude of ``x`` (a no-op for unitless arrays)."""
+    return u.get_magnitude(x)
+
+
+def timeseries_rmse():
+    r"""Build a root-mean-square-error loss between two time series.
+
+    Returns
+    -------
+    callable
+        ``loss(prediction, target) -> scalar`` computing
+        ``sqrt(mean((prediction - target) ** 2))``. The subtraction is
+        unit-checked: incompatible units raise before the magnitude is taken.
+
+    See Also
+    --------
+    fc_rmse : RMSE between functional-connectivity matrices.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from brainmass import objectives
+    >>> loss = objectives.timeseries_rmse()
+    >>> x = jnp.zeros((10, 3))
+    >>> float(loss(x + 2.0, x))
+    2.0
+    """
+
+    def loss(prediction, target):
+        diff = _mag(prediction - target)
+        return jnp.sqrt(jnp.mean(diff ** 2))
+
+    return loss
+
+
+def fc_corr(as_loss=False):
+    r"""Build a functional-connectivity correlation score.
+
+    Computes the correlation between the static functional-connectivity (FC)
+    matrices of the prediction and the target via
+    :func:`braintools.metric.functional_connectivity` and
+    :func:`braintools.metric.matrix_correlation`.
+
+    Parameters
+    ----------
+    as_loss : bool, default False
+        If ``True``, return ``1 - corr`` (a quantity to *minimise*); otherwise
+        return the raw correlation (in ``[-1, 1]``, to *maximise*).
+
+    Returns
+    -------
+    callable
+        ``score(prediction, target) -> scalar``.
+
+    Examples
+    --------
+    >>> import numpy as np, jax.numpy as jnp
+    >>> from brainmass import objectives
+    >>> rng = np.random.default_rng(0)
+    >>> x = jnp.asarray(rng.standard_normal((200, 5)))
+    >>> score = objectives.fc_corr()
+    >>> float(score(x, x))
+    1.0
+    """
+
+    def score(prediction, target):
+        fc_p = braintools.metric.functional_connectivity(_mag(prediction))
+        fc_t = braintools.metric.functional_connectivity(_mag(target))
+        corr = braintools.metric.matrix_correlation(fc_p, fc_t)
+        return 1.0 - corr if as_loss else corr
+
+    return score
+
+
+def fc_rmse():
+    r"""Build a functional-connectivity RMSE loss.
+
+    Returns
+    -------
+    callable
+        ``loss(prediction, target) -> scalar`` computing the RMSE between the
+        prediction's and target's static FC matrices.
+
+    See Also
+    --------
+    fc_corr : correlation between FC matrices.
+    """
+
+    def loss(prediction, target):
+        fc_p = braintools.metric.functional_connectivity(_mag(prediction))
+        fc_t = braintools.metric.functional_connectivity(_mag(target))
+        diff = fc_p - fc_t
+        return jnp.sqrt(jnp.mean(diff ** 2))
+
+    return loss
+
+
+def cosine_sim(as_loss=False, epsilon=0.0):
+    r"""Build a cosine-similarity score between two (flattened) time series.
+
+    Thin wrapper over :func:`braintools.metric.cosine_similarity`; the inputs are
+    flattened to a single vector so the result is a scalar.
+
+    Parameters
+    ----------
+    as_loss : bool, default False
+        If ``True``, return ``1 - cos`` (to *minimise*); otherwise the raw cosine
+        similarity (to *maximise*).
+    epsilon : float, default 0.0
+        Numerical floor forwarded to :func:`braintools.metric.cosine_similarity`.
+
+    Returns
+    -------
+    callable
+        ``score(prediction, target) -> scalar``.
+    """
+
+    def score(prediction, target):
+        cos = braintools.metric.cosine_similarity(
+            _mag(prediction).reshape(-1),
+            _mag(target).reshape(-1),
+            epsilon=epsilon,
+        )
+        return 1.0 - cos if as_loss else cos
+
+    return score
+
+
+def fcd(window_size=30, step_size=5, as_loss=False):
+    r"""Build a functional-connectivity-dynamics (FCD) objective.
+
+    Surfaces :func:`braintools.metric.functional_connectivity_dynamics`, which had
+    no call sites in the package. The FCD matrix captures how the sliding-window
+    functional connectivity itself evolves over time.
+
+    Parameters
+    ----------
+    window_size, step_size : int
+        Sliding-window length and stride (in samples) forwarded to
+        :func:`braintools.metric.functional_connectivity_dynamics`.
+    as_loss : bool, default False
+        If ``True``, return ``1 - corr`` (to *minimise*); otherwise the raw FCD
+        matrix correlation (to *maximise*).
+
+    Returns
+    -------
+    callable
+        ``fn(prediction, target=None)``. With ``target=None`` it returns the
+        prediction's FCD **matrix** (surfacing the metric); with a target it
+        returns the correlation between the two FCD matrices.
+    """
+
+    def fn(prediction, target=None):
+        fcd_p = braintools.metric.functional_connectivity_dynamics(
+            _mag(prediction), window_size=window_size, step_size=step_size
+        )
+        if target is None:
+            return fcd_p
+        fcd_t = braintools.metric.functional_connectivity_dynamics(
+            _mag(target), window_size=window_size, step_size=step_size
+        )
+        corr = braintools.metric.matrix_correlation(fcd_p, fcd_t)
+        return 1.0 - corr if as_loss else corr
+
+    return fn
+
+
+def combine(*weighted_objectives):
+    r"""Combine weighted objective callables into a single objective.
+
+    Parameters
+    ----------
+    *weighted_objectives : tuple of (float, callable)
+        Pairs of ``(weight, objective)`` where each ``objective`` is a callable
+        returned by the builders in this module (signature
+        ``objective(prediction, target)``).
+
+    Returns
+    -------
+    callable
+        ``loss(prediction, target=None) -> scalar`` equal to
+        ``sum(weight * objective(prediction, target))``.
+
+    Examples
+    --------
+    >>> import jax.numpy as jnp
+    >>> from brainmass import objectives
+    >>> loss = objectives.combine(
+    ...     (2.0, objectives.timeseries_rmse()),
+    ...     (0.5, objectives.timeseries_rmse()),
+    ... )
+    >>> x = jnp.zeros((10, 3))
+    >>> float(loss(x + 1.0, x))   # (2.0 + 0.5) * 1.0
+    2.5
+    """
+
+    def loss(prediction, target=None):
+        total = 0.0
+        for weight, objective in weighted_objectives:
+            total = total + weight * objective(prediction, target)
+        return total
+
+    return loss

--- a/brainmass/objectives_test.py
+++ b/brainmass/objectives_test.py
@@ -1,0 +1,201 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for :mod:`brainmass.objectives`.
+
+Each builder is checked against a direct :mod:`braintools.metric` computation (so
+the wrapper adds no drift), plus the known fixed points (self-correlation 1,
+self-RMSE 0), the ``as_loss`` conversions, unit-safety, composition, and
+gradient-safety.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintools
+import brainunit as u
+
+from brainmass import objectives
+
+
+@pytest.fixture
+def signals():
+    """A (prediction, target) pair of (time, regions) arrays."""
+    rng = np.random.default_rng(0)
+    pred = jnp.asarray(rng.standard_normal((200, 6)).astype('float32'))
+    target = jnp.asarray(rng.standard_normal((200, 6)).astype('float32'))
+    return pred, target
+
+
+# --------------------------------------------------------------------------- #
+# timeseries_rmse                                                             #
+# --------------------------------------------------------------------------- #
+
+def test_timeseries_rmse_matches_manual(signals):
+    pred, target = signals
+    got = objectives.timeseries_rmse()(pred, target)
+    expected = jnp.sqrt(jnp.mean((pred - target) ** 2))
+    assert np.allclose(float(got), float(expected))
+
+
+def test_timeseries_rmse_zero_on_identity(signals):
+    pred, _ = signals
+    assert float(objectives.timeseries_rmse()(pred, pred)) == 0.0
+
+
+def test_timeseries_rmse_known_value():
+    x = jnp.zeros((10, 3))
+    assert np.isclose(float(objectives.timeseries_rmse()(x + 2.0, x)), 2.0)
+
+
+def test_timeseries_rmse_unit_safe():
+    x = jnp.ones((10, 2))
+    # Same units: result is a dimensionless scalar magnitude.
+    same = objectives.timeseries_rmse()(x * u.mV, (x + 1.0) * u.mV)
+    assert np.isclose(float(same), 1.0)
+    # Incompatible units must raise (no silent unit dropping).
+    with pytest.raises(Exception):
+        objectives.timeseries_rmse()(x * u.mV, x * u.Hz)
+
+
+# --------------------------------------------------------------------------- #
+# fc_corr / fc_rmse                                                           #
+# --------------------------------------------------------------------------- #
+
+def test_fc_corr_matches_manual(signals):
+    pred, target = signals
+    got = objectives.fc_corr()(pred, target)
+    fc_p = braintools.metric.functional_connectivity(np.asarray(pred))
+    fc_t = braintools.metric.functional_connectivity(np.asarray(target))
+    expected = braintools.metric.matrix_correlation(fc_p, fc_t)
+    assert np.allclose(float(got), float(expected))
+
+
+def test_fc_corr_self_is_one(signals):
+    pred, _ = signals
+    assert np.isclose(float(objectives.fc_corr()(pred, pred)), 1.0, atol=1e-5)
+
+
+def test_fc_corr_as_loss(signals):
+    pred, target = signals
+    score = objectives.fc_corr()(pred, target)
+    loss = objectives.fc_corr(as_loss=True)(pred, target)
+    assert np.allclose(float(loss), 1.0 - float(score))
+
+
+def test_fc_rmse_matches_manual_and_zero_on_identity(signals):
+    pred, target = signals
+    got = objectives.fc_rmse()(pred, target)
+    fc_p = braintools.metric.functional_connectivity(np.asarray(pred))
+    fc_t = braintools.metric.functional_connectivity(np.asarray(target))
+    expected = jnp.sqrt(jnp.mean((fc_p - fc_t) ** 2))
+    assert np.allclose(float(got), float(expected))
+    assert float(objectives.fc_rmse()(pred, pred)) == pytest.approx(0.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# cosine_sim                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_cosine_sim_self_is_one(signals):
+    pred, _ = signals
+    assert np.isclose(float(objectives.cosine_sim()(pred, pred)), 1.0, atol=1e-5)
+
+
+def test_cosine_sim_matches_manual(signals):
+    pred, target = signals
+    got = objectives.cosine_sim()(pred, target)
+    expected = braintools.metric.cosine_similarity(
+        np.asarray(pred).reshape(-1), np.asarray(target).reshape(-1)
+    )
+    assert np.allclose(float(got), float(expected))
+
+
+def test_cosine_sim_as_loss(signals):
+    pred, target = signals
+    score = objectives.cosine_sim()(pred, target)
+    loss = objectives.cosine_sim(as_loss=True)(pred, target)
+    assert np.allclose(float(loss), 1.0 - float(score))
+
+
+# --------------------------------------------------------------------------- #
+# fcd                                                                         #
+# --------------------------------------------------------------------------- #
+
+def test_fcd_surfaces_matrix_when_no_target(signals):
+    pred, _ = signals
+    mat = objectives.fcd(window_size=30, step_size=5)(pred)
+    expected = braintools.metric.functional_connectivity_dynamics(
+        np.asarray(pred), window_size=30, step_size=5
+    )
+    assert np.asarray(mat).shape == np.asarray(expected).shape
+    assert np.asarray(mat).ndim == 2
+
+
+def test_fcd_self_correlation_is_one(signals):
+    pred, _ = signals
+    assert np.isclose(float(objectives.fcd()(pred, pred)), 1.0, atol=1e-5)
+
+
+def test_fcd_as_loss(signals):
+    pred, target = signals
+    score = objectives.fcd()(pred, target)
+    loss = objectives.fcd(as_loss=True)(pred, target)
+    assert np.allclose(float(loss), 1.0 - float(score))
+
+
+# --------------------------------------------------------------------------- #
+# combine                                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_combine_is_weighted_sum(signals):
+    pred, target = signals
+    rmse = objectives.timeseries_rmse()
+    fcl = objectives.fc_corr(as_loss=True)
+    combined = objectives.combine((1.0, rmse), (0.5, fcl))
+    got = combined(pred, target)
+    expected = 1.0 * rmse(pred, target) + 0.5 * fcl(pred, target)
+    assert np.allclose(float(got), float(expected))
+
+
+def test_combine_zero_on_identity(signals):
+    pred, _ = signals
+    combined = objectives.combine(
+        (1.0, objectives.timeseries_rmse()),
+        (1.0, objectives.fc_corr(as_loss=True)),
+    )
+    assert np.isclose(float(combined(pred, pred)), 0.0, atol=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# gradient-safety                                                             #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize('builder', [
+    objectives.timeseries_rmse(),
+    objectives.fc_corr(as_loss=True),
+    objectives.fc_rmse(),
+    objectives.cosine_sim(as_loss=True),
+])
+def test_objectives_are_grad_safe(builder, signals):
+    pred, target = signals
+
+    def loss(scale):
+        return builder(scale * pred, target)
+
+    g = jax.grad(loss)(1.0)
+    assert np.isfinite(float(g))

--- a/brainmass/simulator.py
+++ b/brainmass/simulator.py
@@ -1,0 +1,310 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""A thin, brainstate-native simulation driver.
+
+:class:`Simulator` collapses the copy-pasted ``environ.set(dt)`` ->
+``init_all_states()`` -> ``for_loop(step_run, indices)`` -> collect-``.value``
+idiom into one reusable object that drives any ``brainstate`` ``Dynamics`` /
+``Module`` -- a single node or a whole-brain network -- and returns a unit-aware,
+structured result.
+"""
+
+import math
+import warnings
+
+import brainstate
+import brainunit as u
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+__all__ = [
+    'Simulator',
+]
+
+
+class Simulator:
+    r"""Drive a ``Dynamics`` / ``Module`` and collect monitored trajectories.
+
+    The simulator wraps the standard brainmass run loop -- set ``dt``,
+    initialise states, step the model inside ``environ.context(i=, t=)`` with
+    :func:`brainstate.transform.for_loop`, and stack the recorded values -- in a
+    single :meth:`run` call. It reimplements none of that machinery; it only
+    composes it.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Dynamics or brainstate.nn.Module
+        The model to drive. Exposed afterwards as :attr:`model`. May be a single
+        node or a network whose ``update`` reads its own internal coupling.
+    dt : brainunit.Quantity, optional
+        Integration time step. If ``None`` (default), the step is read from the
+        global environment (``brainstate.environ.get('dt')``) at :meth:`run`
+        time; if that is also unset, :meth:`run` raises ``ValueError``.
+
+    See Also
+    --------
+    brainmass.objectives : composable loss builders over simulated trajectories.
+
+    Notes
+    -----
+    The result of :meth:`run` is a plain ``dict`` (a valid JAX pytree, so it is
+    safe to return through ``jit`` / ``grad`` / ``vmap``) mapping each monitor
+    name to its stacked trajectory, plus a ``'ts'`` time axis. ``ts[k]`` is the
+    simulation time at the **end** of the ``k``-th recorded step (the recorded
+    value is the post-``update`` state).
+
+    Examples
+    --------
+    >>> import brainmass
+    >>> import brainunit as u
+    >>> node = brainmass.HopfStep(2, a=-0.2)
+    >>> sim = brainmass.Simulator(node, dt=0.1 * u.ms)
+    >>> res = sim.run(10.0 * u.ms, monitors=['x'])
+    >>> res['x'].shape
+    (100, 2)
+    >>> res['ts'].shape
+    (100,)
+
+    A derived observable (here ``E - I``) is monitored with a callable:
+
+    >>> jr = brainmass.JansenRitStep(in_size=1)
+    >>> sim = brainmass.Simulator(jr, dt=0.1 * u.ms)
+    >>> res = sim.run(5.0 * u.ms, monitors=lambda m: m.eeg(), transient=1.0 * u.ms)
+    >>> res['output'].shape
+    (40, 1)
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, model, dt=None):
+        self.model = model
+        self.dt = dt
+
+    # ------------------------------------------------------------------ helpers
+
+    def _resolve_dt(self):
+        """Return the run ``dt`` (arg overrides environment); raise if unset."""
+        dt = self.dt
+        if dt is None:
+            dt = brainstate.environ.get('dt', None)
+        if dt is None:
+            raise ValueError(
+                "dt is not set: pass Simulator(model, dt=...) or call "
+                "brainstate.environ.set(dt=...) before run()."
+            )
+        return dt
+
+    @staticmethod
+    def _resolve_steps(duration, dt):
+        """Number of dt-steps in ``duration``; warn (and floor) if not a multiple."""
+        ratio = float(u.get_magnitude(duration / dt))
+        nearest = round(ratio)
+        if abs(ratio - nearest) < 1e-6:
+            n_steps = int(nearest)
+        else:
+            n_steps = int(math.floor(ratio))
+            warnings.warn(
+                f"duration {duration} is not an integer multiple of dt {dt}; "
+                f"truncating to {n_steps} steps.",
+                stacklevel=3,
+            )
+        if n_steps <= 0:
+            raise ValueError(
+                f"duration {duration} yields {n_steps} steps; must be >= 1 dt."
+            )
+        return n_steps
+
+    @staticmethod
+    def _resolve_transient(transient, dt, n_steps):
+        """Leading steps to discard from the output (Quantity duration or count)."""
+        if transient is None:
+            return 0
+        if isinstance(transient, u.Quantity):
+            n_tr = int(round(float(u.get_magnitude(transient / dt))))
+        else:
+            n_tr = int(transient)
+        if n_tr < 0:
+            raise ValueError(f"transient must be >= 0, got {transient!r}.")
+        if n_tr >= n_steps:
+            raise ValueError(
+                f"transient ({n_tr} steps) must be shorter than the run "
+                f"({n_steps} steps); nothing would be recorded."
+            )
+        return n_tr
+
+    @staticmethod
+    def _resolve_sample_every(sample_every):
+        """Validate and normalise the output downsampling stride."""
+        if sample_every is None:
+            return 1
+        k = int(sample_every)
+        if k < 1:
+            raise ValueError(f"sample_every must be >= 1, got {sample_every!r}.")
+        return k
+
+    def _build_measure(self, monitors):
+        """Build ``measure(update_return) -> dict`` for the requested monitors."""
+        model = self.model
+        if monitors is None:
+            return lambda r: {'output': r}
+        if callable(monitors):
+            return lambda r: {'output': monitors(model)}
+        if isinstance(monitors, dict):
+            for name, spec in monitors.items():
+                if isinstance(spec, str) and not hasattr(model, spec):
+                    raise ValueError(
+                        f"monitor {name!r} -> {spec!r} is not an attribute of {model}."
+                    )
+
+            def measure(r):
+                out = {}
+                for name, spec in monitors.items():
+                    out[name] = getattr(model, spec).value if isinstance(spec, str) else spec(model)
+                return out
+
+            return measure
+        # list / tuple of state-attribute names
+        names = list(monitors)
+        for name in names:
+            if not hasattr(model, name):
+                raise ValueError(f"monitor {name!r} is not an attribute of {model}.")
+        return lambda r: {name: getattr(model, name).value for name in names}
+
+    @staticmethod
+    def _build_inputs(inputs, n_steps):
+        """Build ``get_inputs(i, t) -> tuple`` forwarded to ``model.update``."""
+        if inputs is None:
+            return lambda i, t: ()
+        if callable(inputs):
+            def get_inputs(i, t):
+                r = inputs(i, t)
+                return r if isinstance(r, tuple) else (r,)
+            return get_inputs
+        # array-like: one row per step. Convert to a JAX array so it can be
+        # indexed by the traced loop counter (a NumPy array cannot).
+        arr = inputs if isinstance(inputs, u.Quantity) else jnp.asarray(inputs)
+        length = arr.shape[0] if hasattr(arr, 'shape') else len(arr)
+        if length != n_steps:
+            raise ValueError(
+                f"inputs has length {length} but the run has {n_steps} steps."
+            )
+        return lambda i, t: (arr[i],)
+
+    # --------------------------------------------------------------------- run
+
+    def run(
+        self,
+        duration,
+        *,
+        inputs=None,
+        monitors=None,
+        transient=None,
+        sample_every=None,
+        batch_size=None,
+        init_states=True,
+        jit=True,
+    ):
+        """Simulate ``model`` for ``duration`` and return the recorded trajectories.
+
+        Parameters
+        ----------
+        duration : brainunit.Quantity
+            Total simulated time. The number of integration steps is
+            ``int(duration / dt)``; a non-integer multiple is floored with a
+            warning.
+        inputs : None, array-like or callable, optional
+            External drive forwarded to ``model.update``:
+
+            - ``None`` (default): call ``model.update()`` with no arguments.
+            - array-like of shape ``(n_steps, ...)``: row ``i`` is passed as the
+              single argument ``model.update(inputs[i])``.
+            - ``callable(i, t)``: its return is splatted -- ``model.update(*r)``
+              if it returns a tuple, else ``model.update(r)``.
+        monitors : None, list of str, callable or dict, optional
+            What to record each step:
+
+            - ``None`` (default): the return value of ``update()``, under key
+              ``'output'``.
+            - list of state-attribute names (e.g. ``['rE']``): each
+              ``getattr(model, name).value``.
+            - ``callable(model) -> value``: a derived observable, under key
+              ``'output'`` (e.g. ``lambda m: m.eeg()``).
+            - dict mapping output name to a state-attribute name or a
+              ``callable(model)``.
+        transient : None, brainunit.Quantity or int, optional
+            Leading transient to discard from the outputs, as a duration or a
+            step count. Must be shorter than the run.
+        sample_every : None or int, optional
+            Record every ``k``-th step (output downsampling; generalises the
+            Jansen-Rit TR loop). ``None`` records every step.
+        batch_size : None or int, optional
+            If given, initialise states with this batch size (batched initial
+            conditions); outputs gain a leading batch axis.
+        init_states : bool, default True
+            Call ``init_all_states`` before running. Set ``False`` to continue
+            from the model's current state.
+        jit : bool, default True
+            Compile the run with :func:`brainstate.transform.jit`.
+
+        Returns
+        -------
+        dict
+            Maps each monitor name (or ``'output'``) to its stacked trajectory
+            and ``'ts'`` to the time axis. Each trajectory has a leading axis of
+            length ``(n_steps - transient) // sample_every``.
+
+        Raises
+        ------
+        ValueError
+            If ``dt`` is unset, ``transient`` is not shorter than the run, a
+            monitored name is not a model attribute, ``sample_every`` < 1, or the
+            ``inputs`` length does not match the step count.
+        """
+        dt = self._resolve_dt()
+        n_steps = self._resolve_steps(duration, dt)
+        k = self._resolve_sample_every(sample_every)
+        n_tr = self._resolve_transient(transient, dt, n_steps)
+        # Validated early (independent of state initialisation).
+        get_inputs = self._build_inputs(inputs, n_steps)
+
+        # ``dt`` must be live in the environment for both state initialisation
+        # (delay buffers are sized from ``delay / dt``) and the run loop.
+        with brainstate.environ.context(dt=dt):
+            if init_states:
+                if batch_size is None:
+                    brainstate.nn.init_all_states(self.model)
+                else:
+                    brainstate.nn.init_all_states(self.model, batch_size)
+
+            # Built after init so monitored state attributes already exist.
+            measure = self._build_measure(monitors)
+
+            def step_run(i):
+                t = i * dt
+                with brainstate.environ.context(i=i, t=t):
+                    r = self.model.update(*get_inputs(i, t))
+                return measure(r)
+
+            def core():
+                return brainstate.transform.for_loop(step_run, np.arange(n_steps))
+
+            rec = brainstate.transform.jit(core)() if jit else core()
+
+        sl = slice(n_tr, None, k)
+        out = jax.tree.map(lambda a: a[sl], rec)
+        times = (np.arange(n_steps) + 1) * dt
+        out['ts'] = times[sl]
+        return out

--- a/brainmass/simulator_test.py
+++ b/brainmass/simulator_test.py
@@ -1,0 +1,359 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for :class:`brainmass.Simulator`.
+
+Covers the documented contract (shapes, time axis, monitors, inputs, transient,
+sample_every, batching, jit) and every enumerated edge case, plus the two
+"definition of done" equivalences: a single-node run reproduces the hand-written
+``for_loop`` output exactly, and a whole-brain run matches the example-100-style
+hand-wired loop.
+"""
+
+import numpy as np
+import pytest
+
+import braintools
+import brainstate
+import brainunit as u
+
+import brainmass
+from brainmass import Simulator
+
+DT = 0.1 * u.ms
+
+
+# --------------------------------------------------------------------------- #
+# Basic contract                                                              #
+# --------------------------------------------------------------------------- #
+
+def test_model_attribute_exposed():
+    node = brainmass.HopfStep(2, a=-0.2)
+    sim = Simulator(node, dt=DT)
+    assert sim.model is node
+
+
+def test_run_shapes_and_time_axis(seeded):
+    sim = Simulator(brainmass.HopfStep(3, a=-0.2), dt=DT)
+    res = sim.run(10.0 * u.ms, monitors=['x'])
+    assert res['x'].shape == (100, 3)
+    assert res['ts'].shape == (100,)
+    # ts is the time at the END of each step: first = dt, last = duration.
+    assert u.math.allclose(res['ts'][0], DT)
+    assert u.math.allclose(res['ts'][-1], 10.0 * u.ms)
+
+
+def test_dt_read_from_environ(dt):
+    # No dt passed to the Simulator -> it must read the environ dt (set by the
+    # ``dt`` fixture) at run time.
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2))
+    res = sim.run(5.0 * u.ms, monitors=['x'])
+    assert res['x'].shape == (50, 2)
+
+
+def test_dt_unset_raises():
+    brainstate.environ.pop('dt', None)  # restored by the autouse fixture
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2))
+    with pytest.raises(ValueError, match='dt is not set'):
+        sim.run(5.0 * u.ms)
+
+
+# --------------------------------------------------------------------------- #
+# Definition of done: exact reproduction of the manual loop                   #
+# --------------------------------------------------------------------------- #
+
+def test_exact_reproduces_manual_for_loop():
+    """monitors=['x'] reproduces a hand-written for_loop bit-for-bit (seeded)."""
+    brainstate.environ.set(dt=DT)
+
+    brainstate.random.seed(7)
+    manual_model = brainmass.HopfStep(2, a=-0.2)
+    brainstate.nn.init_all_states(manual_model)
+
+    def step(i):
+        manual_model.update()
+        return manual_model.x.value
+
+    manual = brainstate.transform.for_loop(step, np.arange(100))
+
+    brainstate.random.seed(7)
+    res = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(
+        10.0 * u.ms, monitors=['x'], jit=False
+    )
+    assert np.array_equal(np.asarray(manual), np.asarray(res['x']))
+
+
+def test_jit_matches_nojit(seeded):
+    brainstate.random.seed(3)
+    a = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(5.0 * u.ms, monitors=['x'], jit=True)
+    brainstate.random.seed(3)
+    b = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(5.0 * u.ms, monitors=['x'], jit=False)
+    assert np.allclose(np.asarray(a['x']), np.asarray(b['x']), rtol=1e-5, atol=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# Monitors                                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_monitors_none_records_update_return(seeded):
+    res = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(2.0 * u.ms, monitors=None)
+    # HopfStep.update() returns the (x, y) tuple; for_loop stacks each leaf.
+    assert set(res) == {'output', 'ts'}
+    x_out, y_out = res['output']
+    assert x_out.shape == (20, 2) and y_out.shape == (20, 2)
+
+
+def test_monitors_callable_derived_observable(seeded):
+    # eeg() = E - I, a derived observable not stored as a single state.
+    res = Simulator(brainmass.JansenRitStep(in_size=1), dt=DT).run(
+        5.0 * u.ms, monitors=lambda m: m.eeg()
+    )
+    assert res['output'].shape == (50, 1)
+    assert u.get_unit(res['output']) == u.mV
+
+
+def test_monitors_dict_mixed(seeded):
+    res = Simulator(brainmass.JansenRitStep(in_size=1), dt=DT).run(
+        3.0 * u.ms, monitors={'exc': 'E', 'eeg': lambda m: m.eeg()}
+    )
+    assert set(res) == {'exc', 'eeg', 'ts'}
+    assert res['exc'].shape == (30, 1)
+    assert res['eeg'].shape == (30, 1)
+
+
+def test_monitor_missing_attr_raises():
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT)
+    with pytest.raises(ValueError, match='not an attribute'):
+        sim.run(2.0 * u.ms, monitors=['does_not_exist'])
+
+
+def test_monitor_dict_missing_attr_raises():
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT)
+    with pytest.raises(ValueError, match='not an attribute'):
+        sim.run(2.0 * u.ms, monitors={'bad': 'nope'})
+
+
+# --------------------------------------------------------------------------- #
+# Inputs                                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_inputs_array_drives_update(seeded):
+    n_steps = 50
+    drive = np.linspace(0.0, 1.0, n_steps).astype('float32')
+    res = Simulator(brainmass.FitzHughNagumoStep(1), dt=DT).run(
+        5.0 * u.ms, inputs=drive, monitors=['V']
+    )
+    assert res['V'].shape == (50, 1)
+
+
+def test_inputs_array_wrong_length_raises():
+    sim = Simulator(brainmass.FitzHughNagumoStep(1), dt=DT)
+    with pytest.raises(ValueError, match='length'):
+        sim.run(5.0 * u.ms, inputs=np.zeros(7, dtype='float32'), monitors=['V'])
+
+
+def test_inputs_callable_tuple_and_scalar(seeded):
+    # Hopf.update(x_inp, y_inp): callable returns a tuple, splatted into update.
+    res = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(
+        2.0 * u.ms, inputs=lambda i, t: (0.1, 0.0), monitors=['x']
+    )
+    assert res['x'].shape == (20, 2)
+
+    # FHN.update(V_inp): callable returns a single value, wrapped into a 1-tuple.
+    res2 = Simulator(brainmass.FitzHughNagumoStep(1), dt=DT).run(
+        2.0 * u.ms, inputs=lambda i, t: 0.3, monitors=['V']
+    )
+    assert res2['V'].shape == (20, 1)
+
+
+# --------------------------------------------------------------------------- #
+# Transient / sample_every                                                    #
+# --------------------------------------------------------------------------- #
+
+def test_transient_quantity_and_int_discard_leading(seeded):
+    full = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(10.0 * u.ms, monitors=['x'])
+    assert full['x'].shape == (100, 2)
+
+    res_q = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(
+        10.0 * u.ms, monitors=['x'], transient=2.0 * u.ms
+    )
+    assert res_q['x'].shape == (80, 2)
+    # 20 steps discarded; first kept step is index 20, ending at 2.1 ms.
+    assert u.math.allclose(res_q['ts'][0], 2.1 * u.ms)
+
+    res_i = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(
+        10.0 * u.ms, monitors=['x'], transient=20
+    )
+    assert res_i['x'].shape == (80, 2)
+
+
+def test_transient_ge_duration_raises():
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT)
+    with pytest.raises(ValueError, match='shorter than the run'):
+        sim.run(5.0 * u.ms, monitors=['x'], transient=5.0 * u.ms)
+
+
+def test_transient_negative_raises():
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT)
+    with pytest.raises(ValueError, match='>= 0'):
+        sim.run(5.0 * u.ms, monitors=['x'], transient=-1)
+
+
+def test_sample_every_downsamples(seeded):
+    res = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(
+        10.0 * u.ms, monitors=['x'], sample_every=5
+    )
+    assert res['x'].shape == (20, 2)
+    assert res['ts'].shape == (20,)
+    # stride of 5: samples at steps 0, 5, 10, ... -> first ends at 0.1 ms,
+    # consecutive samples spaced 5*dt apart.
+    assert u.math.allclose(res['ts'][0], 0.1 * u.ms)
+    assert u.math.allclose(res['ts'][1] - res['ts'][0], 5 * DT)
+
+
+def test_sample_every_with_transient(seeded):
+    res = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT).run(
+        10.0 * u.ms, monitors=['x'], transient=2.0 * u.ms, sample_every=4
+    )
+    # (100 - 20) steps, every 4th -> 20 samples.
+    assert res['x'].shape == (20, 2)
+
+
+def test_sample_every_invalid_raises():
+    sim = Simulator(brainmass.HopfStep(2, a=-0.2), dt=DT)
+    with pytest.raises(ValueError, match='sample_every'):
+        sim.run(2.0 * u.ms, monitors=['x'], sample_every=0)
+
+
+# --------------------------------------------------------------------------- #
+# Steps resolution                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_non_integer_multiple_warns_and_floors(seeded):
+    with pytest.warns(UserWarning, match='not an integer multiple'):
+        res = Simulator(brainmass.HopfStep(1, a=-0.2), dt=DT).run(1.05 * u.ms, monitors=['x'])
+    assert res['x'].shape == (10, 1)  # floor(10.5)
+
+
+def test_zero_duration_raises():
+    sim = Simulator(brainmass.HopfStep(1, a=-0.2), dt=DT)
+    with pytest.raises(ValueError, match='must be >= 1 dt'):
+        sim.run(0.0 * u.ms)
+
+
+# --------------------------------------------------------------------------- #
+# Units / batching / init                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_units_propagate_through_outputs(seeded):
+    res = Simulator(brainmass.MontbrioPazoRoxinStep(2), dt=DT).run(2.0 * u.ms, monitors=['r'])
+    assert u.get_unit(res['r']) == u.Hz
+
+
+def test_batched_run(seeded):
+    res = Simulator(brainmass.HopfStep(3, a=-0.2), dt=DT).run(
+        2.0 * u.ms, monitors=['x'], batch_size=4
+    )
+    assert res['x'].shape == (20, 4, 3)
+
+
+def test_init_states_false_continues(seeded):
+    # Non-zero IC so the (decaying) trajectory actually moves; the default zero
+    # IC sits exactly on the fixed point and would make the test degenerate.
+    make = lambda: brainmass.HopfStep(
+        2, a=-0.2,
+        init_x=braintools.init.Constant(0.5),
+        init_y=braintools.init.Constant(0.5),
+    )
+    sim = Simulator(make(), dt=DT)
+    first = sim.run(2.0 * u.ms, monitors=['x'])
+    last_state = np.asarray(sim.model.x.value)
+    # Continue WITHOUT re-initialising; the run must pick up from where it left,
+    # so its first sample differs from the first run's first sample.
+    cont = sim.run(2.0 * u.ms, monitors=['x'], init_states=False)
+    assert not np.allclose(np.asarray(cont['x'][0]), np.asarray(first['x'][0]))
+    assert np.all(np.isfinite(np.asarray(cont['x'])))
+    assert last_state.shape == (2,)
+
+
+# --------------------------------------------------------------------------- #
+# Definition of done: gradients flow through run                              #
+# --------------------------------------------------------------------------- #
+
+def test_gradient_flows_through_run():
+    import jax
+    brainstate.environ.set(dt=DT)
+
+    def loss(a):
+        model = brainmass.HopfStep(
+            1, a=a, w=0.2, beta=1.0,
+            init_x=braintools.init.Constant(0.5),
+            init_y=braintools.init.Constant(0.5),
+        )
+        res = Simulator(model, dt=DT).run(2.0 * u.ms, monitors=['x'], jit=False)
+        return u.math.sum(u.get_magnitude(res['x']) ** 2)
+
+    g = float(jax.grad(loss)(-0.2))
+    fd = float((loss(-0.2 + 1e-3) - loss(-0.2 - 1e-3)) / 2e-3)
+    assert np.isfinite(g)
+    assert np.isclose(g, fd, rtol=2e-2, atol=1e-5)
+
+
+# --------------------------------------------------------------------------- #
+# Definition of done: whole-brain run matches hand-wired loop                 #
+# --------------------------------------------------------------------------- #
+
+class _WholeBrain(brainstate.nn.Module):
+    """Minimal example-100-style network: WilsonCowan nodes + diffusive coupling."""
+
+    def __init__(self, sc, delay, k=1.0):
+        super().__init__()
+        n = sc.shape[0]
+        indices = np.tile(np.arange(n), n)
+        self.node = brainmass.WilsonCowanStep(n)
+        self.coupling = brainmass.DiffusiveCoupling(
+            self.node.prefetch_delay(
+                'rE', (delay.flatten(), indices),
+                init=braintools.init.Uniform(0.0, 0.05),
+            ),
+            self.node.prefetch('rE'),
+            sc,
+            k=k,
+        )
+
+    def update(self):
+        current = self.coupling()
+        return self.node(current)
+
+    def step_run(self, i):
+        with brainstate.environ.context(i=i, t=i * brainstate.environ.get_dt()):
+            return self.update()
+
+
+def test_whole_brain_matches_manual_loop(connectome):
+    sc, delay = connectome['SC'], connectome['delay']
+    brainstate.environ.set(dt=DT)
+    n_steps = 60
+
+    brainstate.random.seed(11)
+    manual_net = _WholeBrain(sc, delay)
+    brainstate.nn.init_all_states(manual_net)
+    manual = brainstate.transform.for_loop(manual_net.step_run, np.arange(n_steps))
+
+    brainstate.random.seed(11)
+    sim_net = _WholeBrain(sc, delay)
+    res = Simulator(sim_net, dt=DT).run(n_steps * DT, monitors=None, jit=False)
+
+    assert np.allclose(np.asarray(manual), np.asarray(res['output']), rtol=1e-5, atol=1e-6)

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -39,6 +39,8 @@ The ``brainmass`` package provides the following components:
      - Forward models for mapping neural activity to observed signals (BOLD, EEG/MEG)
    * - :doc:`horn`
      - Harmonic Oscillator Recurrent Networks (HORN) for sequence learning
+   * - :doc:`orchestration`
+     - Simulator driver and composable objective builders for fitting
    * - :doc:`utilities`
      - Utility functions for common operations
 
@@ -78,6 +80,12 @@ Quick Navigation
       :link-type: doc
 
       Harmonic oscillator recurrent networks for temporal sequences
+
+   .. grid-item-card:: Orchestration
+      :link: orchestration
+      :link-type: doc
+
+      Simulator run loop and composable objective builders for parameter fitting
 
    .. grid-item-card:: Utilities & Types
       :link: utilities
@@ -131,4 +139,5 @@ All models are unit-aware via ``brainunit``:
    coupling
    forward
    horn
+   orchestration
    utilities

--- a/docs/api/orchestration.rst
+++ b/docs/api/orchestration.rst
@@ -1,0 +1,68 @@
+Orchestration
+=============
+
+.. currentmodule:: brainmass
+
+The orchestration layer sits *on top of* the neural mass models. It provides the
+reusable run loop and the loss/score builders that earlier had to be hand-written
+in every example and tutorial:
+
+- :class:`Simulator` drives any model (single node or whole-brain network) and
+  collects monitored trajectories into a unit-aware result.
+- :mod:`brainmass.objectives` composes :mod:`braintools.metric` into small,
+  jit / grad / vmap-safe objective callables over those trajectories.
+
+
+Simulator
+---------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   Simulator
+
+.. autoclass:: Simulator
+   :members:
+   :special-members: __init__
+
+
+Objectives
+----------
+
+.. currentmodule:: brainmass.objectives
+
+Each function is a *builder*: it takes configuration and returns a small
+``callable(prediction, target)`` that wraps :mod:`braintools.metric` without
+reimplementing any metric maths. The callables are designed to be composed via
+:func:`combine` into the loss a fitter minimises.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   timeseries_rmse
+   fc_corr
+   fc_rmse
+   cosine_sim
+   fcd
+   combine
+
+.. autofunction:: timeseries_rmse
+
+.. autofunction:: fc_corr
+
+.. autofunction:: fc_rmse
+
+.. autofunction:: cosine_sim
+
+.. autofunction:: fcd
+
+.. autofunction:: combine
+
+
+See Also
+--------
+
+- :doc:`models` - the neural mass models that :class:`Simulator` drives
+- :doc:`coupling` - building multi-region networks to simulate

--- a/examples/000-getting-started.ipynb
+++ b/examples/000-getting-started.ipynb
@@ -305,11 +305,7 @@
    "cell_type": "markdown",
    "id": "step5-header",
    "metadata": {},
-   "source": [
-    "### Step 5: Run the Simulation\n",
-    "\n",
-    "Define a step function and run the simulation using BrainState's efficient `for_loop`:"
-   ]
+   "source": "### Step 5: Run the Simulation\n\nDrive the model with `brainmass.Simulator` — a thin wrapper that sets `dt`, steps the model, and collects the states you monitor into a unit-aware result. Under the hood it uses BrainState's compiled `for_loop`, so you keep the speed without writing the boilerplate."
   },
   {
    "cell_type": "code",
@@ -320,35 +316,9 @@
      "start_time": "2026-03-21T13:51:09.773123200Z"
     }
    },
-   "source": [
-    "# Define the simulation step\n",
-    "def step_run(i):\n",
-    "    \"\"\"Single simulation step.\"\"\"\n",
-    "    node.update()  # Update model dynamics\n",
-    "    return node.x.value, node.y.value  # Return state values\n",
-    "\n",
-    "\n",
-    "# Simulate for 1000 ms (10,000 steps at dt=0.1ms)\n",
-    "n_steps = 10000\n",
-    "indices = np.arange(n_steps)\n",
-    "\n",
-    "# Run simulation (compiled with JAX JIT for speed)\n",
-    "x_trace, y_trace = brainstate.transform.for_loop(step_run, indices)\n",
-    "\n",
-    "print(f\"Simulation complete!\")\n",
-    "print(f\"Output shape: {x_trace.shape} (time steps, nodes)\")"
-   ],
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Simulation complete!\n",
-      "Output shape: (10000, 1) (time steps, nodes)\n"
-     ]
-    }
-   ],
-   "execution_count": 5
+   "source": "# `brainmass.Simulator` collapses the manual \"define step_run -> for_loop ->\n# collect .value\" idiom into a single call. It drives any node or network,\n# records the states (or derived observables) you ask for, and returns a\n# unit-aware time axis under `res['ts']`.\nsim = brainmass.Simulator(node, dt=dt)\n\n# Simulate for 1000 ms (10,000 steps at dt=0.1 ms). Reuse the states we\n# initialised in Step 4 (init_states=False) and record both x and y.\nn_steps = 10000\nres = sim.run(n_steps * dt, monitors=['x', 'y'], init_states=False)\n\nx_trace, y_trace = res['x'], res['y']\nindices = np.arange(n_steps)  # reused for the time axis / exploration cells below\n\nprint(\"Simulation complete!\")\nprint(f\"Output shape: {x_trace.shape} (time steps, nodes)\")",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

First goal of the orchestration sub-project (A1: 06 → 07 → 08). Adds the in-package run loop and loss builders that previously had to be hand-written in every example/tutorial. **Purely additive** — no model API is touched; both new modules only *compose* existing `brainstate`/`braintools` primitives.

### `brainmass.Simulator`
A thin, brainstate-native driver: `Simulator(model, dt).run(duration, *, inputs, monitors, transient, sample_every, batch_size, init_states, jit)` collapses the standard `environ.context(dt)` → `init_all_states()` → `for_loop(step_run)` → collect-`.value` idiom into one call, returning a unit-aware `dict` `{monitor: trajectory, 'ts': time_axis}` (a clean pytree through jit/grad/vmap).

- `inputs`: `None` / `(n_steps, …)` array / `callable(i, t)`
- `monitors`: `None` (update return) / `list[str]` state names / `callable(model)` derived observable / `dict`
- `transient`: `Quantity` or step count; `sample_every`: output stride (generalises the Jansen-Rit TR loop)
- `batch_size`: batched ICs (leading batch axis); `init_states=False` continues from current state

Verified: a seeded single-node run is **bit-identical** to a hand-written `for_loop`; a whole-brain WilsonCowan + DiffusiveCoupling net matches a manual loop; `jax.grad` through `run` matches finite differences.

### `brainmass.objectives`
Composable, jit/grad/vmap-safe loss/score builders over simulated trajectories — thin wrappers over `braintools.metric` with no reimplemented maths: `timeseries_rmse`, `fc_corr`, `fc_rmse`, `cosine_sim`, `fcd`, `combine`. `fcd` finally surfaces `functional_connectivity_dynamics` (previously zero call sites). RMSE is unit-checked; FC/cosine are scale-invariant on magnitudes.

### Docs & example
- Migrated `examples/000-getting-started.ipynb` Step 5 to use `Simulator` (boilerplate collapses; trajectory unchanged).
- New `docs/api/orchestration.rst` (autodoc'd). Docstring examples are **doctest-gated** — `sphinx -b doctest` now 102 tests, 0 failures.

## Testing
- `simulator_test.py` (27 tests) + `objectives_test.py` (20 tests).
- Full suite: **384 passed**; coverage **98.42%** (`simulator.py` and `objectives.py` both **100%**).

## Out of scope
Connectome builder (goal-07) and fitter (goal-08).