### PR TITLE
feat: add brainmass.Fitter — one fitter, three optimizer backends (goal-08)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -382,3 +382,63 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
   initializer + tests + docstrings + notebooks); `pytest -W error::DeprecationWarning` now passes (was 232
   warnings / 26 collection errors). **Lesson:** when scoping a deprecation fix, reproduce the *actual*
   warnings and trace every trigger — don't estimate from the obvious parameter pattern alone.
+
+### 2026-06-18 · goal-08 orchestration-fitter
+
+- **`brainmass.Fitter(model, optimizer=None, *, loss_fn=None, objective=None, predict=None,
+  backend='grad', callbacks=None, transient=None, search_space=None)`** + **`FitResult`** collapse the 7
+  copy-pasted `ModelFitting` classes (in the untracked `tutorials/` scratch dir) into one object.
+  `.fit(target=None, n_steps=100, *, verbose=False) -> FitResult`. "Write the objective once; swap
+  backends." `FitResult` carries `backend, best_loss, best_params{name:constrained}, history, n_steps,
+  prediction, optimizer, raw, model`.
+- **`optimizer` is backend-polymorphic** (the key unification trick): for `backend='grad'` it is a
+  `braintools.optim.OptaxOptimizer` instance (default `Adam(lr=1e-2)`); for `'nevergrad'`/`'scipy'` it is
+  an **options dict** (`{'method':'DE','n_sample':8}` / `{'method':'L-BFGS-B'}`) or a method-name `str` or
+  `None` — the real `NevergradOptimizer`/`ScipyOptimizer` is built *inside* `.fit()` (it needs the loss +
+  bounds at construction) and exposed as `fitter.optimizer`. `n_steps` = optax steps / nevergrad
+  generations / scipy random-restarts.
+- **Two loss paths:** `loss_fn(model)->(scalar, aux)` is the *entire* loss (user owns reg); else
+  `objective(predict(model)[transient:], target) + model.reg_loss()` with `objective` defaulting to
+  `objectives.timeseries_rmse()`. `predict(model)->prediction` is a user-built `Simulator` closure (keeps
+  the constructor free of duration/monitors). `transient` is an **int sample count** trimmed off axis 0.
+- **grad backend = the canonical invariant, verbatim:** `weights = model.states(ParamState)` (empty →
+  clear `ValueError`); `optimizer.register_trainable_weights(weights)`; jitted closure
+  `grad(f_loss, weights, has_aux=True, return_value=True)` → `optimizer.step(grads)`; `f_loss` runs inside
+  `with model.param_precompute():`. Track a **best-seen checkpoint** (snapshot `{path: state.value}` on
+  improvement, restore at end) so the model ends at its best, not its last, point. Step-for-step it
+  reproduces a hand-rolled `ModelFitting` loop (`fitter_test::test_grad_matches_handrolled` asserts
+  `allclose` history).
+- **search_space derivation from Param transforms** (`_finite_box`): only transforms with a *finite*
+  interval auto-derive a box — `SigmoidT/TanhT/SoftsignT/ScaledSigmoidT` via `(.lower, .lower+.width)`,
+  `ClipT` via `(.lower,.upper)`. Half-line/unbounded (`ReluT`(`.lower_bound`!), `SoftplusT/LogT/ExpT`
+  (`.lower` only), `NegSoftplusT` (`.lower` stores upper), `PositiveT/NegativeT/IdentityT`) → **no box** →
+  raise naming the param unless an explicit `search_space[name]` is given (which always overrides). Bounds
+  are built at the param's value shape (`jnp.full(shape, lo/hi)`; scalars stay scalar) so candidate shape
+  matches `set_value`.
+- **⚠ optimizer gotcha for goals 09-10 — derivative-free candidates MUST be looped, not vmapped.**
+  `brainstate.transform.vmap` over `Param.set_value` raises `BatchAxisError` (the written ParamState isn't
+  in `out_states`) — same family as goal-07's batched-delay limitation. So the Nevergrad `batched_loss_fun`
+  evaluates its `n_sample` candidates with a **Python `for` loop** (set_value→predict→objective, stacked);
+  fine for the few scalar params derivative-free search suits, but it does NOT scale to matrix params.
+  `Param.set_value(constrained)` stores `t.inverse(constrained)` and `value()` returns `t.forward` — they
+  round-trip, so the search box lives in constrained/physical space and the transform constraint is
+  redundant-but-harmless there.
+- **Backend availability:** `scipy` is a hard `braintools` dep (always present); **`nevergrad` is only a
+  braintools `testing` extra** — added to `requirements-dev.txt` so CI installs it, and the nevergrad tests
+  `pytest.importorskip('nevergrad')` for robustness. SciPy *gradient* methods (`L-BFGS-B`) DO differentiate
+  through `set_value` (verified); a `timeseries_rmse` loss is V-shaped (`|k−k*|·const`) with a sqrt kink at
+  the optimum, so a single restart can stall — use a few restarts (`n_steps≈3`) for derivative-free robustness.
+- **callbacks/early-stop** are a **grad-backend feature** (the Fitter owns that loop): each
+  `callback({'step','loss','best_loss','model'})` fires per step and returning `True` stops early.
+  Derivative-free backends run `.minimize(n_iter)` to completion (their loop is internal), so callbacks
+  there fire once at the end — documented, not silently dropped.
+- **Migration:** rewrote `docs/tutorials/parameter_fitting.rst` around `Fitter` (was schematic
+  hand-rolled snippets + a nonexistent `brainmass.ArrayParam`) — all blocks are runnable `.. testcode::`
+  (3-region drive so `fc_corr`/`cosine_sim` are non-degenerate). Added `Fitter`/`FitResult` autoclass to
+  `docs/apis/orchestration.rst`. Real nodes (`HopfStep`, `WilsonCowanStep`) expose **no** trainable
+  `ParamState` by default — fitting requires wrapping the target parameter in a `Param(..., t=...)` (as the
+  `tutorials/` models do, e.g. `JansenRitTR(k=Param(5.5, t=ReluT(0.5)))`).
+- **Local coverage is unmeasurable in this WSL env:** `pytest --cov` (and `COVERAGE_CORE=sysmon|pytrace`)
+  **SIGABRT** with JAX imported — reproduces on pre-existing test files too, so it is environmental, not a
+  code bug. CI (Linux) measures the `--cov-fail-under=90` gate fine. Audit branch coverage by reading the
+  code + tests instead; full suite is **439 passed** (403 + 36 new) locally without `--cov`.

--- a/brainmass/__init__.py
+++ b/brainmass/__init__.py
@@ -98,6 +98,7 @@ from .wilson_cowan import (
 from .wong_wang import WongWangStep
 # Orchestration layer
 from . import objectives
+from .fitter import Fitter, FitResult
 from .network import Network
 from .simulator import Simulator
 
@@ -177,6 +178,8 @@ __all__ = [
     # Orchestration layer
     'Network',
     'Simulator',
+    'Fitter',
+    'FitResult',
     'objectives',
 ]
 

--- a/brainmass/fitter.py
+++ b/brainmass/fitter.py
@@ -1,0 +1,564 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""One reusable model fitter spanning three optimizer backends.
+
+:class:`Fitter` collapses the copy-pasted ``ModelFitting`` classes -- the
+``weights = model.states(ParamState)`` -> ``register_trainable_weights`` ->
+jitted ``grad`` -> ``optimizer.step`` loop, repeated verbatim in every fitting
+tutorial -- into a single object. You write the objective once and swap the
+optimizer backend:
+
+- ``backend='grad'`` -- gradient descent through the differentiable model with a
+  :mod:`braintools.optim` optax optimizer (the canonical loop above).
+- ``backend='nevergrad'`` -- gradient-free evolutionary search over a bounded
+  ``search_space`` with :class:`braintools.optim.NevergradOptimizer`.
+- ``backend='scipy'`` -- :class:`braintools.optim.ScipyOptimizer` (gradient or
+  gradient-free SciPy methods) over the same ``search_space``.
+
+It reimplements none of that machinery; it only composes the existing pieces --
+brainstate :class:`~brainstate.nn.Param` (constrained parameters + transforms +
+``reg_loss`` + ``param_precompute``), :class:`brainmass.Simulator`,
+:mod:`brainmass.objectives`, and the :mod:`braintools.optim` optimizers.
+"""
+
+import braintools
+import brainstate
+import jax.numpy as jnp
+import numpy as np
+from brainstate.nn import Param
+
+from . import objectives as _objectives
+
+__all__ = [
+    'Fitter',
+    'FitResult',
+]
+
+_BACKENDS = ('grad', 'nevergrad', 'scipy')
+
+
+# --------------------------------------------------------------------------- #
+# Parameter / search-space helpers                                            #
+# --------------------------------------------------------------------------- #
+
+def _trainable_params(model):
+    """Return ``{dotted_name: Param}`` for every trainable ``Param`` in ``model``.
+
+    Walks ``model.nodes()`` and keeps the :class:`~brainstate.nn.Param`
+    submodules whose ``fit`` flag is ``True`` (so ``Const`` / ``fit=False``
+    parameters are excluded). The name is the dotted node path, e.g. ``'k'`` for
+    a top-level attribute or ``'node.k'`` for a nested one.
+    """
+    out = {}
+    for path, node in model.nodes().items():
+        if isinstance(node, Param) and node.fit:
+            out['.'.join(str(p) for p in path)] = node
+    return out
+
+
+def _finite_box(transform):
+    """Return the ``(lower, upper)`` constrained interval of ``transform``, or None.
+
+    Only transforms that define a *finite* interval expose usable derivative-free
+    bounds: :class:`~brainstate.nn.SigmoidT` / ``TanhT`` / ``SoftsignT`` /
+    ``ScaledSigmoidT`` (via ``lower`` + ``width``) and :class:`~brainstate.nn.ClipT`
+    (via ``lower`` + ``upper``). Half-line / unbounded transforms (``ReluT``,
+    ``SoftplusT``, ``PositiveT``, ``IdentityT`` ...) return ``None`` and require an
+    explicit ``search_space`` entry.
+    """
+    lower = getattr(transform, 'lower', None)
+    if lower is None:
+        return None
+    width = getattr(transform, 'width', None)
+    if width is not None:
+        return lower, lower + width
+    upper = getattr(transform, 'upper', None)
+    if upper is not None:
+        return lower, upper
+    return None
+
+
+def _shaped_bounds(lo, hi, shape):
+    """Broadcast a scalar ``(lo, hi)`` pair to the parameter's value shape."""
+    if shape == ():
+        return (lo, hi)
+    return (jnp.full(shape, lo), jnp.full(shape, hi))
+
+
+def _build_search_space(params, user_search_space):
+    """Resolve ``{name: (low, high)}`` bounds for the derivative-free backends.
+
+    User-supplied bounds override the bounds derived from each parameter's
+    transform. Raises ``ValueError`` for a parameter that has neither a finite
+    transform interval nor an explicit entry, and for an explicit entry naming a
+    parameter that is not trainable.
+    """
+    user = dict(user_search_space or {})
+    for name in user:
+        if name not in params:
+            raise ValueError(
+                f"search_space names unknown parameter {name!r}; trainable "
+                f"parameters are {sorted(params)}."
+            )
+    bounds = {}
+    for name, p in params.items():
+        shape = jnp.shape(p.value())
+        if name in user:
+            lo, hi = user[name]
+        else:
+            box = _finite_box(p.t)
+            if box is None:
+                raise ValueError(
+                    f"cannot derive search bounds for trainable parameter "
+                    f"{name!r}: its transform {type(p.t).__name__} defines no "
+                    f"finite interval. Pass search_space={{{name!r}: (low, high)}}."
+                )
+            lo, hi = box
+        bounds[name] = _shaped_bounds(lo, hi, shape)
+    return bounds
+
+
+# --------------------------------------------------------------------------- #
+# Result container                                                            #
+# --------------------------------------------------------------------------- #
+
+class FitResult:
+    """Outcome of a :meth:`Fitter.fit` call.
+
+    Attributes
+    ----------
+    backend : str
+        The optimizer backend that produced this result (``'grad'`` /
+        ``'nevergrad'`` / ``'scipy'``).
+    best_loss : float
+        Lowest loss observed over the run.
+    best_params : dict
+        ``{name: value}`` of the trainable parameters at the best-seen point, in
+        the *constrained* (physical) space (i.e. ``Param.value()``).
+    history : list of float
+        Per-iteration loss. For ``grad`` this is one entry per optimization step;
+        for ``scipy`` it is the best loss per restart; for ``nevergrad`` it is the
+        loss of every evaluated candidate.
+    n_steps : int
+        Number of optimization iterations actually run (may be less than the
+        requested ``n_steps`` if a callback requested early stopping).
+    prediction : Any or None
+        The model prediction at the best-seen point (objective path), else ``None``.
+    optimizer : Any
+        The underlying :mod:`braintools.optim` optimizer object.
+    raw : Any
+        Backend-specific raw result (a SciPy ``OptimizeResult`` for ``scipy``,
+        the best-parameter mapping for ``nevergrad``, ``None`` for ``grad``).
+    model : brainstate.nn.Module
+        The fitted model, holding the best-seen parameters.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        *,
+        backend,
+        best_loss,
+        best_params,
+        history,
+        n_steps,
+        prediction=None,
+        optimizer=None,
+        raw=None,
+        model=None,
+    ):
+        self.backend = backend
+        self.best_loss = best_loss
+        self.best_params = best_params
+        self.history = history
+        self.n_steps = n_steps
+        self.prediction = prediction
+        self.optimizer = optimizer
+        self.raw = raw
+        self.model = model
+
+    def __repr__(self):
+        names = ', '.join(self.best_params)
+        return (
+            f"FitResult(backend={self.backend!r}, best_loss={self.best_loss:.6g}, "
+            f"n_steps={self.n_steps}, params=[{names}])"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Fitter                                                                      #
+# --------------------------------------------------------------------------- #
+
+class Fitter:
+    r"""Fit a model's trainable parameters to data behind one ``.fit`` call.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model to fit. Its trainable :class:`~brainstate.nn.Param` parameters
+        (``fit=True``) are the optimization variables.
+    optimizer : optional
+        Interpreted by ``backend``:
+
+        - ``'grad'``: a :class:`braintools.optim.OptaxOptimizer` instance
+          (e.g. ``braintools.optim.Adam(lr=0.05)``). Defaults to ``Adam(lr=1e-2)``.
+        - ``'nevergrad'`` / ``'scipy'``: an options ``dict`` forwarded to the
+          optimizer constructor (e.g. ``{'method': 'DE', 'n_sample': 8}`` or
+          ``{'method': 'L-BFGS-B'}``), a method-name ``str``, or ``None``. The
+          actual optimizer is constructed inside :meth:`fit` (it needs the loss
+          and bounds) and exposed afterwards as :attr:`optimizer`.
+    loss_fn : callable, optional
+        ``loss_fn(model) -> (scalar_loss, aux)``. When given it is the *entire*
+        loss (you own any regularization) and ``objective`` / ``predict`` /
+        ``target`` are unused. Mutually exclusive with ``predict``.
+    objective : callable, optional
+        ``objective(prediction, target) -> scalar`` (e.g. from
+        :mod:`brainmass.objectives`). Used with ``predict``. Defaults to
+        :func:`brainmass.objectives.timeseries_rmse`.
+    predict : callable, optional
+        ``predict(model) -> prediction``; typically a :class:`brainmass.Simulator`
+        closure. Required unless ``loss_fn`` is given. The objective-path loss is
+        ``objective(prediction[transient:], target) + model.reg_loss()``.
+    backend : {'grad', 'nevergrad', 'scipy'}, default 'grad'
+        Which optimizer backend to use.
+    callbacks : list of callable, optional
+        Each ``callback(info) -> bool | None`` is called once per step with
+        ``info = {'step', 'loss', 'best_loss', 'model'}``. Returning ``True``
+        stops the run early (``grad`` backend only).
+    transient : int, optional
+        Number of leading samples discarded from the prediction (axis 0) before
+        the objective is applied. ``None`` keeps the whole prediction.
+    search_space : dict, optional
+        ``{name: (low, high)}`` constrained bounds for the derivative-free
+        backends, overriding/augmenting the bounds derived from each parameter's
+        transform.
+
+    See Also
+    --------
+    brainmass.Simulator : builds the ``predict`` closure.
+    brainmass.objectives : composable objective callables.
+
+    Notes
+    -----
+    The ``grad`` backend reproduces the canonical hand-rolled loop exactly:
+    ``model.states(ParamState)`` are registered as trainable weights, the loss is
+    evaluated inside ``model.param_precompute()``, and
+    ``brainstate.transform.grad(..., has_aux=True, return_value=True)`` feeds
+    ``optimizer.step``. ``model.reg_loss()`` is added automatically. The
+    derivative-free backends evaluate one candidate at a time (setting parameters
+    via ``Param.set_value`` then running ``predict``) -- ``vmap`` over parameter
+    writes is unsupported, so candidates are looped, which is why these backends
+    suit a small number of scalar parameters.
+
+    Examples
+    --------
+    >>> import braintools, brainstate, brainunit as u
+    >>> import jax.numpy as jnp
+    >>> import brainmass
+    >>> from brainstate.nn import Param, SigmoidT
+    >>> class Toy(brainstate.nn.Module):
+    ...     def __init__(self):
+    ...         super().__init__()
+    ...         self.k = Param(1.0, t=SigmoidT(0.5, 3.0))
+    ...     def update(self):
+    ...         return self.k.value()
+    >>> def predict(m):
+    ...     sim = brainmass.Simulator(m, dt=0.1 * u.ms)
+    ...     return jnp.mean(sim.run(1.0 * u.ms, monitors=None)['output'])
+    >>> fitter = brainmass.Fitter(Toy(), braintools.optim.Adam(lr=0.1), predict=predict)
+    >>> result = fitter.fit(target=jnp.asarray(2.0), n_steps=30)
+    >>> result.backend
+    'grad'
+    >>> list(result.best_params)
+    ['k']
+    >>> bool(result.best_loss <= result.history[0])
+    True
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        model,
+        optimizer=None,
+        *,
+        loss_fn=None,
+        objective=None,
+        predict=None,
+        backend='grad',
+        callbacks=None,
+        transient=None,
+        search_space=None,
+    ):
+        if backend not in _BACKENDS:
+            raise ValueError(f"backend must be one of {_BACKENDS}, got {backend!r}.")
+        if loss_fn is None and predict is None:
+            raise ValueError(
+                "provide either loss_fn=callable(model)->(loss, aux) or "
+                "predict=callable(model)->prediction."
+            )
+        if loss_fn is not None and predict is not None:
+            raise ValueError("pass loss_fn or predict, not both.")
+
+        self.model = model
+        self.backend = backend
+        self._optimizer_arg = optimizer
+        self._optimizer = None
+        self.loss_fn = loss_fn
+        self.predict = predict
+        self.objective = (
+            objective if objective is not None
+            else (_objectives.timeseries_rmse() if loss_fn is None else None)
+        )
+        self.callbacks = list(callbacks or [])
+        self.transient = transient
+        self.search_space = search_space
+
+    # ----------------------------------------------------------------- helpers
+
+    @property
+    def optimizer(self):
+        """The underlying optimizer (constructed lazily for derivative-free backends)."""
+        return self._optimizer if self._optimizer is not None else self._optimizer_arg
+
+    def _trim(self, prediction):
+        """Drop the leading ``transient`` samples from a prediction (axis 0)."""
+        if self.transient is None:
+            return prediction
+        return prediction[self.transient:]
+
+    def _eval(self, model, target):
+        """Return ``(loss, aux)`` for ``model`` (objective path adds ``reg_loss``)."""
+        if self.loss_fn is not None:
+            return self.loss_fn(model)
+        prediction = self.predict(model)
+        loss = self.objective(self._trim(prediction), target) + model.reg_loss()
+        return loss, prediction
+
+    def _eval_candidate(self, params, values, target):
+        """Set ``values`` onto ``params`` then return the scalar loss."""
+        for name, val in values.items():
+            params[name].set_value(val)
+        loss, _ = self._eval(self.model, target)
+        return loss
+
+    @staticmethod
+    def _apply_params(params, values):
+        """Write ``values`` (constrained space) back onto ``params``."""
+        for name, val in values.items():
+            params[name].set_value(val)
+
+    def _run_callbacks(self, step, loss, best_loss):
+        """Invoke every callback; return ``True`` if any requests early stop."""
+        info = {'step': step, 'loss': loss, 'best_loss': best_loss, 'model': self.model}
+        stop = False
+        for cb in self.callbacks:
+            if cb(info) is True:
+                stop = True
+        return stop
+
+    def _derivfree_opts(self):
+        """Normalise the ``optimizer`` argument into a kwargs dict for the backend."""
+        arg = self._optimizer_arg
+        if arg is None:
+            return {}
+        if isinstance(arg, str):
+            return {'method': arg}
+        if isinstance(arg, dict):
+            return dict(arg)
+        raise TypeError(
+            f"for backend={self.backend!r}, optimizer must be a method name (str), "
+            f"an options dict, or None; got {type(arg).__name__}."
+        )
+
+    # -------------------------------------------------------------------- fit
+
+    def fit(self, target=None, n_steps=100, *, verbose=False):
+        """Run the optimization and return a :class:`FitResult`.
+
+        Parameters
+        ----------
+        target : Any, optional
+            The data the objective compares the prediction against. Unused when a
+            ``loss_fn`` was supplied (it consumes data itself).
+        n_steps : int, default 100
+            Optimization iterations: optax steps (``grad``), generations
+            (``nevergrad``), or random restarts (``scipy``). Must be >= 1.
+        verbose : bool, default False
+            Print per-iteration progress.
+
+        Returns
+        -------
+        FitResult
+            The best-seen loss, parameters, history, and the fitted model.
+        """
+        if int(n_steps) < 1:
+            raise ValueError(f"n_steps must be >= 1, got {n_steps!r}.")
+        if self.backend == 'grad':
+            return self._fit_grad(target, int(n_steps), verbose)
+        if self.backend == 'nevergrad':
+            return self._fit_nevergrad(target, int(n_steps), verbose)
+        return self._fit_scipy(target, int(n_steps), verbose)
+
+    # --------------------------------------------------------------- backends
+
+    def _fit_grad(self, target, n_steps, verbose):
+        weights = self.model.states(brainstate.ParamState)
+        if len(weights) == 0:
+            raise ValueError(
+                "model has no trainable parameters (brainstate.ParamState); set "
+                "fit=True on at least one Param to fit with backend='grad'."
+            )
+        optimizer = self._optimizer_arg
+        if optimizer is None:
+            optimizer = braintools.optim.Adam(lr=1e-2)
+        elif not isinstance(optimizer, braintools.optim.OptaxOptimizer):
+            raise TypeError(
+                "backend='grad' requires a braintools.optim optimizer "
+                f"(e.g. Adam(lr=...)) or None; got {type(optimizer).__name__}."
+            )
+        optimizer.register_trainable_weights(weights)
+        self._optimizer = optimizer
+
+        def f_loss():
+            with self.model.param_precompute():
+                return self._eval(self.model, target)
+
+        @brainstate.transform.jit
+        def f_train():
+            f_grad = brainstate.transform.grad(
+                f_loss, weights, has_aux=True, return_value=True
+            )
+            grads, loss, aux = f_grad()
+            optimizer.step(grads)
+            return loss, aux
+
+        history = []
+        best_loss = float('inf')
+        best_snapshot = None
+        best_pred = None
+        step = 0
+        for step in range(n_steps):
+            loss, aux = f_train()
+            loss_f = float(loss)
+            history.append(loss_f)
+            if loss_f < best_loss:
+                best_loss = loss_f
+                best_snapshot = {k: jnp.asarray(v.value) for k, v in weights.items()}
+                best_pred = aux
+            if verbose:
+                print(f"[grad] step {step}: loss={loss_f:.6g} best={best_loss:.6g}")
+            if self._run_callbacks(step, loss_f, best_loss):
+                break
+
+        # Restore the best-seen weights so the model ends at its best point.
+        if best_snapshot is not None:
+            for k, v in weights.items():
+                v.value = best_snapshot[k]
+
+        best_params = {name: p.value() for name, p in _trainable_params(self.model).items()}
+        return FitResult(
+            backend='grad',
+            best_loss=best_loss,
+            best_params=best_params,
+            history=history,
+            n_steps=step + 1,
+            prediction=best_pred,
+            optimizer=optimizer,
+            raw=None,
+            model=self.model,
+        )
+
+    def _fit_nevergrad(self, target, n_steps, verbose):
+        params = _trainable_params(self.model)
+        bounds = self._resolve_bounds(params)
+        names = list(bounds)
+        opts = self._derivfree_opts()
+        method = opts.pop('method', 'DE')
+        n_sample = int(opts.pop('n_sample', 8))
+
+        def batched(**stacked):
+            losses = []
+            for i in range(n_sample):
+                values = {name: stacked[name][i] for name in names}
+                losses.append(self._eval_candidate(params, values, target))
+            return jnp.asarray(losses)
+
+        optimizer = braintools.optim.NevergradOptimizer(
+            batched, bounds, n_sample=n_sample, method=method, **opts
+        )
+        self._optimizer = optimizer
+        best = optimizer.minimize(n_iter=n_steps, verbose=verbose)
+
+        errors = np.asarray(optimizer.errors, dtype=float)
+        best_loss = float(np.nanmin(errors))
+        self._apply_params(params, best)
+        best_params = {name: p.value() for name, p in params.items()}
+        best_pred = None if self.loss_fn is not None else self.predict(self.model)
+        return FitResult(
+            backend='nevergrad',
+            best_loss=best_loss,
+            best_params=best_params,
+            history=[float(e) for e in errors],
+            n_steps=n_steps,
+            prediction=best_pred,
+            optimizer=optimizer,
+            raw=best,
+            model=self.model,
+        )
+
+    def _fit_scipy(self, target, n_steps, verbose):
+        params = _trainable_params(self.model)
+        bounds = self._resolve_bounds(params)
+        names = list(bounds)
+        opts = self._derivfree_opts()
+        method = opts.pop('method', None)
+
+        def loss(**candidate):
+            values = {name: candidate[name] for name in names}
+            return self._eval_candidate(params, values, target)
+
+        optimizer = braintools.optim.ScipyOptimizer(
+            loss, bounds, method=method, **opts
+        )
+        self._optimizer = optimizer
+        res = optimizer.minimize(n_iter=n_steps)
+
+        best_loss = float(res.fun)
+        self._apply_params(params, res.x)
+        best_params = {name: p.value() for name, p in params.items()}
+        best_pred = None if self.loss_fn is not None else self.predict(self.model)
+        if verbose:
+            print(f"[scipy] best loss={best_loss:.6g} success={getattr(res, 'success', None)}")
+        return FitResult(
+            backend='scipy',
+            best_loss=best_loss,
+            best_params=best_params,
+            history=[best_loss],
+            n_steps=n_steps,
+            prediction=best_pred,
+            optimizer=optimizer,
+            raw=res,
+            model=self.model,
+        )
+
+    def _resolve_bounds(self, params):
+        """Build the derivative-free search bounds, erroring when nothing to search."""
+        if len(params) == 0 and not self.search_space:
+            raise ValueError(
+                "model has no trainable parameters and no search_space was given; "
+                f"backend={self.backend!r} needs at least one parameter to search."
+            )
+        return _build_search_space(params, self.search_space)

--- a/brainmass/fitter_test.py
+++ b/brainmass/fitter_test.py
@@ -1,0 +1,446 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for :class:`brainmass.Fitter` and :class:`brainmass.FitResult`.
+
+Covers the documented contract for all three backends (``grad`` / ``nevergrad`` /
+``scipy``), the ``search_space`` derivation from ``Param`` transforms, the loss
+paths (objective vs custom ``loss_fn``), constrained round-tripping, callbacks /
+early-stop, every enumerated edge-case error, and the "definition of done"
+equivalence: the ``grad`` backend reproduces a hand-rolled ``ModelFitting`` loop
+step for step.
+"""
+
+import numpy as np
+import pytest
+
+import braintools
+import brainstate
+import brainunit as u
+import jax.numpy as jnp
+from brainstate.nn import Param, Const, SigmoidT, ReluT, ClipT, IdentityT
+
+import brainmass
+from brainmass import Fitter, FitResult
+from brainmass.fitter import (
+    _trainable_params,
+    _finite_box,
+    _build_search_space,
+)
+
+DT = 1.0 * u.ms
+TARGET = jnp.asarray(2.0)
+
+
+# --------------------------------------------------------------------------- #
+# Toy models + predict                                                        #
+# --------------------------------------------------------------------------- #
+
+class ScalarToy(brainstate.nn.Module):
+    """A single bounded scalar ``k`` whose ``update`` returns ``k``."""
+
+    def __init__(self, init=1.0, t=None):
+        super().__init__()
+        self.k = Param(init, t=SigmoidT(0.5, 3.0) if t is None else t)
+
+    def update(self):
+        return self.k.value()
+
+
+class MixedToy(brainstate.nn.Module):
+    """A trainable bounded ``k`` plus a fixed ``Const`` offset (non-trainable)."""
+
+    def __init__(self):
+        super().__init__()
+        self.k = Param(1.0, t=SigmoidT(0.5, 3.0))
+        self.offset = Const(0.0)
+
+    def update(self):
+        return self.k.value() + self.offset.value()
+
+
+class ConstOnly(brainstate.nn.Module):
+    """No trainable parameters at all."""
+
+    def __init__(self):
+        super().__init__()
+        self.c = Const(1.0)
+
+    def update(self):
+        return self.c.value()
+
+
+def scalar_predict(model):
+    """Mean of a short noise-free run -> a scalar that equals ``k``."""
+    sim = brainmass.Simulator(model, dt=DT)
+    return jnp.mean(sim.run(3.0 * DT, monitors=None)['output'])
+
+
+@pytest.fixture(autouse=True)
+def _dt():
+    brainstate.environ.set(dt=DT)
+    yield
+    brainstate.environ.pop('dt', None)
+
+
+# --------------------------------------------------------------------------- #
+# Exports / FitResult                                                         #
+# --------------------------------------------------------------------------- #
+
+def test_exports():
+    assert brainmass.Fitter is Fitter
+    assert brainmass.FitResult is FitResult
+    assert 'Fitter' in brainmass.__all__
+    assert 'FitResult' in brainmass.__all__
+
+
+def test_fitresult_repr():
+    r = FitResult(
+        backend='grad', best_loss=0.125, best_params={'k': jnp.asarray(2.0)},
+        history=[1.0, 0.5, 0.125], n_steps=3,
+    )
+    text = repr(r)
+    assert 'grad' in text and 'k' in text and '0.125' in text
+
+
+# --------------------------------------------------------------------------- #
+# search-space derivation helpers                                             #
+# --------------------------------------------------------------------------- #
+
+def test_trainable_params_excludes_const():
+    params = _trainable_params(MixedToy())
+    assert set(params) == {'k'}  # offset (Const) excluded
+
+
+def test_finite_box_sigmoid():
+    lo, hi = _finite_box(SigmoidT(0.5, 3.0))
+    assert (float(lo), float(hi)) == (0.5, 3.0)
+
+
+def test_finite_box_clip():
+    lo, hi = _finite_box(ClipT(-1.0, 4.0))
+    assert (float(lo), float(hi)) == (-1.0, 4.0)
+
+
+def test_finite_box_unbounded_returns_none():
+    assert _finite_box(ReluT(0.0)) is None
+    assert _finite_box(IdentityT()) is None
+
+
+def test_build_search_space_autoderive():
+    bounds = _build_search_space(_trainable_params(ScalarToy()), None)
+    assert set(bounds) == {'k'}
+    lo, hi = bounds['k']
+    assert (float(lo), float(hi)) == (0.5, 3.0)
+
+
+def test_build_search_space_user_override():
+    bounds = _build_search_space(_trainable_params(ScalarToy()), {'k': (1.0, 2.0)})
+    lo, hi = bounds['k']
+    assert (float(lo), float(hi)) == (1.0, 2.0)
+
+
+def test_build_search_space_unbounded_requires_explicit():
+    params = _trainable_params(ScalarToy(t=ReluT(0.0)))
+    with pytest.raises(ValueError, match="cannot derive search bounds"):
+        _build_search_space(params, None)
+    # ... but works once given explicitly.
+    bounds = _build_search_space(params, {'k': (0.5, 3.0)})
+    assert set(bounds) == {'k'}
+
+
+def test_build_search_space_unknown_name():
+    with pytest.raises(ValueError, match="unknown parameter"):
+        _build_search_space(_trainable_params(ScalarToy()), {'nope': (0.0, 1.0)})
+
+
+def test_build_search_space_array_param_shape():
+    class VecToy(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = Param(jnp.ones(4), t=SigmoidT(0.0, 1.0))
+
+    bounds = _build_search_space(_trainable_params(VecToy()), None)
+    lo, hi = bounds['w']
+    assert jnp.shape(lo) == (4,) and jnp.shape(hi) == (4,)
+
+
+# --------------------------------------------------------------------------- #
+# Backends reduce loss                                                        #
+# --------------------------------------------------------------------------- #
+
+def test_grad_reduces_loss():
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1), predict=scalar_predict)
+    r = fitter.fit(target=TARGET, n_steps=40)
+    assert r.backend == 'grad'
+    assert r.best_loss <= r.history[0]
+    assert r.best_loss < 0.05
+    assert abs(float(r.best_params['k']) - 2.0) < 0.1
+    # the model holds the best-seen parameters after fitting
+    assert abs(float(fitter.model.k.value()) - 2.0) < 0.1
+
+
+def test_grad_default_optimizer():
+    fitter = Fitter(ScalarToy(), predict=scalar_predict)  # optimizer=None -> Adam
+    r = fitter.fit(target=TARGET, n_steps=30)
+    assert isinstance(fitter.optimizer, braintools.optim.OptaxOptimizer)
+    assert r.best_loss <= r.history[0]
+
+
+def test_nevergrad_reduces_loss(seeded):
+    pytest.importorskip('nevergrad')
+    fitter = Fitter(ScalarToy(), {'method': 'DE', 'n_sample': 6},
+                    predict=scalar_predict, backend='nevergrad')
+    r = fitter.fit(target=TARGET, n_steps=15)
+    assert r.backend == 'nevergrad'
+    assert r.best_loss < 0.05
+    assert abs(float(r.best_params['k']) - 2.0) < 0.1
+    assert len(r.history) > 0
+
+
+def test_scipy_reduces_loss(seeded):
+    fitter = Fitter(ScalarToy(), 'Nelder-Mead', predict=scalar_predict, backend='scipy')
+    r = fitter.fit(target=TARGET, n_steps=1, verbose=True)
+    assert r.backend == 'scipy'
+    assert r.best_loss < 0.05
+    assert abs(float(r.best_params['k']) - 2.0) < 0.1
+    # raw SciPy OptimizeResult is exposed
+    assert hasattr(r.raw, 'x')
+
+
+def test_nevergrad_default_options(seeded):
+    pytest.importorskip('nevergrad')
+    # optimizer=None -> default DE method + default n_sample.
+    fitter = Fitter(ScalarToy(), predict=scalar_predict, backend='nevergrad')
+    r = fitter.fit(target=TARGET, n_steps=5)
+    assert np.isfinite(r.best_loss)
+
+
+def test_optimizer_property_before_and_after_fit():
+    opt = braintools.optim.Adam(lr=0.1)
+    fitter = Fitter(ScalarToy(), opt, predict=scalar_predict)
+    assert fitter.optimizer is opt           # before fit: returns the argument
+    fitter.fit(target=TARGET, n_steps=2)
+    assert fitter.optimizer is opt           # after fit: the registered optimizer
+
+
+def test_scipy_gradient_method(seeded):
+    # L-BFGS-B (a gradient method) traces through Param.set_value.
+    fitter = Fitter(ScalarToy(), {'method': 'L-BFGS-B'},
+                    predict=scalar_predict, backend='scipy')
+    r = fitter.fit(target=TARGET, n_steps=1)
+    assert abs(float(r.best_params['k']) - 2.0) < 0.1
+
+
+# --------------------------------------------------------------------------- #
+# DoD: grad reproduces a hand-rolled ModelFitting loop                        #
+# --------------------------------------------------------------------------- #
+
+def test_grad_matches_handrolled_modelfitting():
+    n_steps = 25
+
+    # --- Fitter (grad backend) ---
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1), predict=scalar_predict)
+    res = fitter.fit(target=TARGET, n_steps=n_steps)
+
+    # --- hand-rolled canonical ModelFitting loop on an identical model ---
+    model = ScalarToy()
+    weights = model.states(brainstate.ParamState)
+    opt = braintools.optim.Adam(lr=0.1)
+    opt.register_trainable_weights(weights)
+
+    def f_loss():
+        with model.param_precompute():
+            pred = scalar_predict(model)
+            loss = jnp.sqrt(jnp.mean((pred - TARGET) ** 2)) + model.reg_loss()
+        return loss, pred
+
+    @brainstate.transform.jit
+    def f_train():
+        fg = brainstate.transform.grad(f_loss, weights, has_aux=True, return_value=True)
+        grads, loss, pred = fg()
+        opt.step(grads)
+        return loss
+
+    hand_history = [float(f_train()) for _ in range(n_steps)]
+
+    # Step-for-step identical numerics (same init, optimizer, objective).
+    np.testing.assert_allclose(res.history, hand_history, rtol=1e-4, atol=1e-5)
+    assert abs(res.history[-1] - hand_history[-1]) < 1e-4
+
+
+# --------------------------------------------------------------------------- #
+# FCD objective works through the Fitter                                      #
+# --------------------------------------------------------------------------- #
+
+def test_fcd_objective_runs():
+    # A deterministic, time-varying multi-region prediction so FCD is well-defined.
+    t = jnp.linspace(0.0, 6.28, 60)[:, None]
+    base = jnp.sin(t * jnp.arange(1, 4)[None, :])  # (60, 3)
+    target = jnp.cos(t * jnp.arange(1, 4)[None, :])
+
+    def predict_ts(model):
+        return base * model.k.value()
+
+    fitter = Fitter(
+        ScalarToy(), braintools.optim.Adam(lr=0.05),
+        predict=predict_ts,
+        objective=brainmass.objectives.fcd(window_size=20, step_size=5, as_loss=True),
+    )
+    r = fitter.fit(target=target, n_steps=3)
+    assert np.isfinite(r.best_loss)
+
+
+# --------------------------------------------------------------------------- #
+# Loss paths                                                                  #
+# --------------------------------------------------------------------------- #
+
+def test_loss_fn_path():
+    def loss_fn(model):
+        pred = scalar_predict(model)
+        return (pred - TARGET) ** 2, pred
+
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1), loss_fn=loss_fn)
+    r = fitter.fit(n_steps=40)
+    assert r.best_loss < 0.05
+    assert abs(float(r.best_params['k']) - 2.0) < 0.1
+
+
+def test_loss_fn_path_nevergrad(seeded):
+    pytest.importorskip('nevergrad')
+
+    def loss_fn(model):
+        pred = scalar_predict(model)
+        return (pred - TARGET) ** 2, pred
+
+    fitter = Fitter(ScalarToy(), {'n_sample': 6}, loss_fn=loss_fn, backend='nevergrad')
+    r = fitter.fit(n_steps=12)
+    assert r.prediction is None  # loss_fn path does not re-run predict
+    assert r.best_loss < 0.05
+
+
+def test_transient_trims_prediction():
+    captured = {}
+
+    def predict_ts(model):
+        return jnp.ones((10, 2)) * model.k.value()
+
+    def objective(pred, target):
+        captured['len'] = pred.shape[0]
+        return jnp.mean((pred - target) ** 2)
+
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.05),
+                    predict=predict_ts, objective=objective, transient=4)
+    fitter.fit(target=jnp.ones((6, 2)) * 2.0, n_steps=1)
+    assert captured['len'] == 6  # 10 - 4 transient samples
+
+
+# --------------------------------------------------------------------------- #
+# Callbacks / early-stop                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_callbacks_called():
+    seen = []
+
+    def cb(info):
+        seen.append(info['step'])
+
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1),
+                    predict=scalar_predict, callbacks=[cb])
+    fitter.fit(target=TARGET, n_steps=5)
+    assert seen == [0, 1, 2, 3, 4]
+
+
+def test_early_stop():
+    def cb(info):
+        return info['step'] >= 2  # stop after the 3rd step
+
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1),
+                    predict=scalar_predict, callbacks=[cb])
+    r = fitter.fit(target=TARGET, n_steps=50)
+    assert r.n_steps == 3
+    assert len(r.history) == 3
+
+
+# --------------------------------------------------------------------------- #
+# Constrained round-trip                                                      #
+# --------------------------------------------------------------------------- #
+
+def test_constrained_roundtrip():
+    p = Param(1.5, t=SigmoidT(0.5, 3.0))
+    p.set_value(jnp.asarray(2.25))
+    assert abs(float(p.value()) - 2.25) < 1e-4  # value round-trips through transform
+
+
+def test_fit_respects_bounds(seeded):
+    # An optimum (4.0) outside the (0.5, 3.0) box must be clamped to the bound.
+    fitter = Fitter(ScalarToy(), 'Nelder-Mead', predict=scalar_predict, backend='scipy')
+    r = fitter.fit(target=jnp.asarray(4.0), n_steps=2)
+    assert float(r.best_params['k']) <= 3.0 + 1e-4
+
+
+# --------------------------------------------------------------------------- #
+# Edge-case errors                                                            #
+# --------------------------------------------------------------------------- #
+
+def test_unknown_backend():
+    with pytest.raises(ValueError, match="backend must be one of"):
+        Fitter(ScalarToy(), predict=scalar_predict, backend='nope')
+
+
+def test_requires_loss_or_predict():
+    with pytest.raises(ValueError, match="loss_fn.*or.*predict"):
+        Fitter(ScalarToy())
+
+
+def test_loss_and_predict_mutually_exclusive():
+    with pytest.raises(ValueError, match="not both"):
+        Fitter(ScalarToy(), loss_fn=lambda m: (0.0, None), predict=scalar_predict)
+
+
+def test_grad_no_trainable_params():
+    fitter = Fitter(ConstOnly(), braintools.optim.Adam(lr=0.1), predict=scalar_predict)
+    with pytest.raises(ValueError, match="no trainable parameters"):
+        fitter.fit(target=TARGET, n_steps=3)
+
+
+def test_derivfree_no_trainable_params():
+    fitter = Fitter(ConstOnly(), 'Nelder-Mead', predict=scalar_predict, backend='scipy')
+    with pytest.raises(ValueError, match="no trainable parameters"):
+        fitter.fit(target=TARGET, n_steps=1)
+
+
+def test_grad_wrong_optimizer_type():
+    fitter = Fitter(ScalarToy(), {'method': 'DE'}, predict=scalar_predict)  # dict for grad
+    with pytest.raises(TypeError, match="braintools.optim optimizer"):
+        fitter.fit(target=TARGET, n_steps=2)
+
+
+def test_derivfree_bad_optimizer_type():
+    fitter = Fitter(ScalarToy(), 123, predict=scalar_predict, backend='scipy')
+    with pytest.raises(TypeError, match="method name"):
+        fitter.fit(target=TARGET, n_steps=1)
+
+
+def test_n_steps_must_be_positive():
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1), predict=scalar_predict)
+    with pytest.raises(ValueError, match="n_steps must be >= 1"):
+        fitter.fit(target=TARGET, n_steps=0)
+
+
+def test_verbose_runs(capsys):
+    fitter = Fitter(ScalarToy(), braintools.optim.Adam(lr=0.1), predict=scalar_predict)
+    fitter.fit(target=TARGET, n_steps=2, verbose=True)
+    assert '[grad]' in capsys.readouterr().out

--- a/docs/apis/orchestration.rst
+++ b/docs/apis/orchestration.rst
@@ -12,6 +12,9 @@ be hand-written in every example and tutorial:
   collects monitored trajectories into a unit-aware result.
 - :mod:`brainmass.objectives` composes :mod:`braintools.metric` into small,
   jit / grad / vmap-safe objective callables over those trajectories.
+- :class:`Fitter` fits a model's trainable parameters to data behind one
+  ``.fit`` call, swapping between gradient (optax), Nevergrad, and SciPy
+  backends without rewriting the objective.
 
 
 Network
@@ -40,6 +43,24 @@ Simulator
 .. autoclass:: Simulator
    :members:
    :special-members: __init__
+
+
+Fitter
+------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   Fitter
+   FitResult
+
+.. autoclass:: Fitter
+   :members:
+   :special-members: __init__
+
+.. autoclass:: FitResult
+   :members:
 
 
 Objectives

--- a/docs/tutorials/parameter_fitting.rst
+++ b/docs/tutorials/parameter_fitting.rst
@@ -1,473 +1,240 @@
 Parameter Fitting
 ==================
 
-This tutorial covers optimizing model parameters to match empirical data.
+This tutorial fits a model's parameters to data with :class:`brainmass.Fitter` --
+one object that wraps the *write-the-objective-once, swap-the-backend* workflow.
+You build a ``predict`` closure and an objective once, then fit with gradient
+descent, Nevergrad, or SciPy by changing a single ``backend`` argument.
 
 .. note::
 
-   The snippets on this page are *schematic*: parameter fitting requires empirical data and a
-   full simulation driver, so the optimization examples below are illustrative and not executed
-   in the documentation build. For the runnable simulation building blocks they rely on (model
-   construction, stepping, coupling, BOLD) see :doc:`quickstart` and :doc:`building_networks`.
+   Every code block on this page is executed as part of the documentation build
+   (via ``sphinx.ext.doctest``), so the snippets are guaranteed to run against the
+   current API. The integration time step ``dt`` is global state set through
+   ``brainstate.environ`` -- it is **not** a model argument.
 
 
 Overview
 --------
 
-Parameter fitting workflow:
-
-1. Define a loss function comparing model output to data
-2. Choose an optimization method
-3. Run optimization to find best parameters
-4. Validate fitted parameters
-
-
-Loss Functions
---------------
-
-Functional Connectivity Loss
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Most common for fMRI data:
-
-.. code-block:: python
-
-   import jax.numpy as jnp
-
-   def fc_loss(params, SC, FC_empirical):
-       """Loss based on functional connectivity matching"""
-
-       # Run simulation with params
-       bold_sim = simulate_network(params, SC)
-
-       # Compute simulated FC
-       FC_sim = jnp.corrcoef(bold_sim.T)
-
-       # Compare to empirical FC
-       # Option 1: Correlation
-       FC_corr = jnp.corrcoef(FC_sim.flatten(), FC_empirical.flatten())[0, 1]
-       loss = 1.0 - FC_corr  # minimize (1 - correlation)
-
-       # Option 2: MSE
-       # loss = jnp.mean((FC_sim - FC_empirical) ** 2)
-
-       return loss
-
-
-Time Series Loss
-^^^^^^^^^^^^^^^^
-
-For EEG/MEG or other time-domain data:
-
-.. code-block:: python
-
-   def timeseries_loss(params, data_empirical):
-       """Direct time series matching"""
-
-       # Simulate
-       data_sim = simulate_eeg(params)
-
-       # MSE loss
-       loss = jnp.mean((data_sim - data_empirical) ** 2)
-
-       return loss
-
-
-Power Spectrum Loss
-^^^^^^^^^^^^^^^^^^^
-
-Match frequency content:
-
-.. code-block:: python
-
-   from scipy import signal
-
-   def psd_loss(params, psd_empirical, freqs_empirical):
-       """Match power spectral density"""
-
-       # Simulate and compute PSD
-       ts_sim = simulate(params)
-       freqs_sim, psd_sim = signal.welch(ts_sim, fs=1000)
-
-       # Interpolate to match empirical frequencies
-       psd_sim_interp = jnp.interp(freqs_empirical, freqs_sim, psd_sim)
-
-       # Log-space MSE (better for power spectra)
-       loss = jnp.mean((jnp.log(psd_sim_interp) - jnp.log(psd_empirical)) ** 2)
-
-       return loss
-
-
-Optimization Methods
---------------------
-
-Gradient-Free (Nevergrad)
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Best for non-differentiable objectives:
-
-.. code-block:: python
-
-   import nevergrad as ng
-   import brainmass
-   import jax.numpy as jnp
-
-   # Load data
-   SC = jnp.load('SC.npy')
-   FC_emp = jnp.load('FC_empirical.npy')
-
-   # Define simulation function
-   def simulate_network(coupling_strength):
-       nodes = brainmass.WongWangStep(in_size=90)
-       coupling = brainmass.DiffusiveCoupling(conn=SC, k=coupling_strength)
-       bold = brainmass.BOLDSignal(in_size=90)
-
-       nodes.init_all_states()
-       coupling.init_all_states()
-       bold.init_all_states()
-
-       # Simulate (simplified)
-       neural_ts = []
-       for t in range(10000):
-           S_E = nodes.S_E.value
-           coupled = coupling(S_E, S_E)
-           out = nodes.update(S_E_ext=coupled)
-           neural_ts.append(out)
-
-       neural_ts = jnp.stack(neural_ts)
-
-       # Generate BOLD
-       bold_ts = []
-       for z in neural_ts:
-           bold.update(z=z)
-           bold_ts.append(bold.bold())
-
-       return jnp.stack(bold_ts)[::2000]  # downsample
-
-   # Define loss
-   def objective(coupling_strength):
-       bold_sim = simulate_network(coupling_strength)
-       FC_sim = jnp.corrcoef(bold_sim.T)
-       corr = jnp.corrcoef(FC_sim.flatten(), FC_emp.flatten())[0, 1]
-       return 1.0 - corr  # minimize
-
-   # Setup optimization
-   instrum = ng.p.Scalar(init=0.2, lower=0.0, upper=1.0)
-   optimizer = ng.optimizers.NGOpt(parametrization=instrum, budget=50)
-
-   # Run optimization
-   for i in range(50):
-       x = optimizer.ask()
-       loss = objective(x.value)
-       optimizer.tell(x, loss)
-       print(f"Iteration {i}: k={x.value:.3f}, loss={loss:.4f}")
-
-   # Best parameters
-   recommendation = optimizer.provide_recommendation()
-   best_k = recommendation.value
-   print(f"Best coupling strength: {best_k:.3f}")
-
-
-Gradient-Based (JAX + Optax)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-For differentiable models:
-
-.. code-block:: python
-
-   import jax
-   import jax.numpy as jnp
-   import optax
-   import brainmass
-
-   # Define differentiable simulation
-   @jax.jit
-   def simulate_and_loss(k, SC, FC_emp):
-       # Simplified differentiable simulation
-       # (full network simulation needs careful state management)
-
-       # ... simulation code ...
-
-       FC_sim = jnp.corrcoef(bold_sim.T)
-       loss = jnp.mean((FC_sim - FC_emp) ** 2)
-
-       return loss
-
-   # Setup optimizer
-   learning_rate = 1e-3
-   optimizer = optax.adam(learning_rate)
-
-   # Initial parameters
-   params = {'k': 0.2}
-   opt_state = optimizer.init(params)
-
-   # Training loop
-   for epoch in range(100):
-       # Compute gradients
-       loss, grads = jax.value_and_grad(simulate_and_loss)(
-           params['k'], SC, FC_emp
-       )
-
-       # Update parameters
-       updates, opt_state = optimizer.update(grads, opt_state)
-       params = optax.apply_updates(params, updates)
-
-       if epoch % 10 == 0:
-           print(f"Epoch {epoch}: k={params['k']:.3f}, loss={loss:.4f}")
-
-
-SciPy Optimizers
-^^^^^^^^^^^^^^^^
-
-Good for moderate-dimensional problems:
-
-.. code-block:: python
-
-   from scipy.optimize import minimize
-   import jax.numpy as jnp
-
-   def objective(params):
-       k, noise_sigma = params
-       # ... simulate ...
-       loss = fc_loss(k, noise_sigma, FC_emp)
-       return loss
-
-   # Initial guess
-   x0 = [0.2, 0.01]
-
-   # Optimize
-   result = minimize(
-       objective,
-       x0,
-       method='Nelder-Mead',
-       options={'maxiter': 100}
-   )
-
-   best_params = result.x
-   print(f"Best parameters: k={best_params[0]:.3f}, sigma={best_params[1]:.4f}")
-
-
-Multi-Parameter Optimization
------------------------------
-
-Optimizing Multiple Parameters
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-   import nevergrad as ng
-
-   # Define parameter space
-   instrum = ng.p.Instrumentation(
-       coupling_k=ng.p.Scalar(init=0.2, lower=0.0, upper=1.0),
-       noise_sigma=ng.p.Scalar(init=0.01, lower=0.0, upper=0.1),
-       tau_E=ng.p.Scalar(init=10.0, lower=5.0, upper=50.0),
-       tau_I=ng.p.Scalar(init=20.0, lower=10.0, upper=100.0),
-   )
-
-   optimizer = ng.optimizers.NGOpt(parametrization=instrum, budget=200)
-
-   def multi_param_objective(coupling_k, noise_sigma, tau_E, tau_I):
-       # Simulate with all parameters
-       # ...
-       return loss
-
-   # Optimize
-   for i in range(200):
-       x = optimizer.ask()
-       loss = multi_param_objective(**x.kwargs)
-       optimizer.tell(x, loss)
-
-
-Constrained Parameters
-^^^^^^^^^^^^^^^^^^^^^^
-
-Use :class:`ArrayParam` for constraints:
-
-.. code-block:: python
+The fitting workflow has four pieces:
+
+1. A model with one or more **trainable parameters** -- a
+   :class:`brainstate.nn.Param` with ``fit=True`` (the default). A transform such
+   as :class:`~brainstate.nn.SigmoidT` keeps the parameter inside physical bounds.
+2. A ``predict(model) -> prediction`` closure, usually a :class:`brainmass.Simulator`
+   run that returns a ``(time, regions)`` trajectory.
+3. An **objective** comparing the prediction to data, from
+   :mod:`brainmass.objectives`.
+4. A :class:`~brainmass.Fitter` that minimises the loss with the chosen backend.
+
+
+A Model, a Prediction, and an Objective
+---------------------------------------
+
+We use a minimal differentiable model with a single bounded gain ``k``. The
+``SigmoidT(0.1, 5.0)`` transform constrains ``k`` to ``(0.1, 5.0)`` -- and those
+bounds are later reused, verbatim, as the search box for the gradient-free
+backends. The synthetic target is generated with a "true" gain of ``2.0``:
+
+.. testcode::
 
    import brainmass
    import braintools
+   import brainstate
+   import brainunit as u
+   import jax.numpy as jnp
+   from brainstate.nn import Param, SigmoidT
 
-   # Create constrained parameter (must be positive)
-   tau_param = brainmass.ArrayParam(
-       data=10.0,  # initial value
-       transform=braintools.SoftplusTransform(),
+   brainstate.environ.set(dt=0.1 * u.ms)
+
+   class GainModel(brainstate.nn.Module):
+       def __init__(self, init_gain=1.0):
+           super().__init__()
+           # Trainable, bounded parameter; stored unconstrained, exposed in (0.1, 5.0).
+           self.k = Param(init_gain, t=SigmoidT(0.1, 5.0))
+
+       def update(self, x):
+           return self.k.value() * x
+
+   # A fixed 3-region drive and the target it should reproduce at the true gain k = 2.0.
+   t = jnp.linspace(0.0, 6.28, 40)[:, None]
+   drive = jnp.sin(t * jnp.arange(1, 4))        # (40, 3): three distinct channels
+   target = 2.0 * drive
+
+   # predict(model) -> (time, regions): one Simulator run over the drive.
+   def predict(model):
+       sim = brainmass.Simulator(model, dt=0.1 * u.ms)
+       return sim.run(4.0 * u.ms, inputs=drive, monitors=None)['output']
+
+   # Write the objective ONCE, then reuse it for every backend below.
+   objective = brainmass.objectives.timeseries_rmse()
+
+
+Gradient-Based (optax)
+----------------------
+
+The ``grad`` backend is the canonical loop: it registers the model's trainable
+``ParamState`` weights with the :mod:`braintools.optim` optimizer, differentiates
+the loss through the (differentiable) model, and steps the optimizer.
+``model.reg_loss()`` is added automatically and parameter transforms keep ``k``
+inside its bounds.
+
+.. testcode::
+
+   fitter = brainmass.Fitter(
+       GainModel(),
+       braintools.optim.Adam(lr=0.2),
+       predict=predict,
+       objective=objective,
+       backend='grad',
    )
+   result = fitter.fit(target=target, n_steps=60)
+   print(f"grad: fitted k = {float(result.best_params['k']):.2f}")
+   assert result.best_loss <= result.history[0]
 
-   # Optimize in unconstrained space
-   def objective(tau_unconstrained):
-       tau_param.value = tau_unconstrained
-       tau_actual = tau_param.data  # always positive
 
-       # Use tau_actual in simulation
-       # ...
-       return loss
+Gradient-Free (Nevergrad)
+-------------------------
+
+Swap ``backend='nevergrad'`` to search the same parameter with an evolutionary
+algorithm -- useful when the objective is non-differentiable. The search box is
+**derived automatically** from the ``SigmoidT`` transform, so no bounds need to be
+spelled out. For the derivative-free backends the ``optimizer`` argument is an
+options dict (or a method-name string):
+
+.. testcode::
+
+   fitter = brainmass.Fitter(
+       GainModel(),
+       {'method': 'DE', 'n_sample': 8},
+       predict=predict,
+       objective=objective,
+       backend='nevergrad',
+   )
+   result = fitter.fit(target=target, n_steps=20)
+   print(f"nevergrad: fitted k = {float(result.best_params['k']):.1f}")
+
+
+SciPy
+-----
+
+``backend='scipy'`` runs :class:`braintools.optim.ScipyOptimizer`. Gradient
+methods (``L-BFGS-B``) differentiate through the parameter assignment;
+gradient-free methods (``Nelder-Mead``) work too. ``n_steps`` is the number of
+random restarts -- a few restarts make the search robust to a poor starting
+point:
+
+.. testcode::
+
+   fitter = brainmass.Fitter(
+       GainModel(),
+       {'method': 'L-BFGS-B'},
+       predict=predict,
+       objective=objective,
+       backend='scipy',
+   )
+   result = fitter.fit(target=target, n_steps=3)
+   print(f"scipy: fitted k = {float(result.best_params['k']):.2f}")
+
+
+Search Spaces from Transforms
+-----------------------------
+
+The gradient-free backends search a bounded box per parameter. The bounds are
+derived from each parameter's transform where the transform defines a finite
+interval:
+
+- :class:`~brainstate.nn.SigmoidT` / ``TanhT`` / ``SoftsignT`` / ``ScaledSigmoidT``
+  -> ``(lower, upper)``
+- :class:`~brainstate.nn.ClipT` -> ``(lower, upper)``
+
+Half-line or unbounded transforms (``ReluT``, ``SoftplusT``, ``PositiveT``,
+``IdentityT``, ...) define no finite box, so you must pass an explicit
+``search_space`` (which also overrides any derived bound):
+
+.. testcode::
+
+   from brainstate.nn import ReluT
+
+   class PositiveGain(brainstate.nn.Module):
+       def __init__(self):
+           super().__init__()
+           self.k = Param(1.0, t=ReluT(0.0))   # lower bound only -> no finite box
+
+       def update(self, x):
+           return self.k.value() * x
+
+   fitter = brainmass.Fitter(
+       PositiveGain(),
+       {'method': 'L-BFGS-B'},
+       predict=predict,
+       objective=objective,
+       backend='scipy',
+       search_space={'k': (0.1, 5.0)},          # supply the box explicitly
+   )
+   result = fitter.fit(target=target, n_steps=1)
+   assert 0.1 <= float(result.best_params['k']) <= 5.0
+
+
+Custom Loss Functions
+---------------------
+
+When the loss is more than ``objective(prediction, target)`` -- multiple terms,
+custom weighting, data captured in a closure -- pass ``loss_fn(model) ->
+(scalar_loss, aux)`` instead of ``predict`` + ``objective``. It is the entire loss
+(you own any regularization):
+
+.. testcode::
+
+   def loss_fn(model):
+       pred = predict(model)
+       rmse = brainmass.objectives.timeseries_rmse()
+       cos = brainmass.objectives.cosine_sim(as_loss=True)
+       loss = rmse(pred, target) + 0.1 * cos(pred, target)
+       return loss, pred
+
+   fitter = brainmass.Fitter(GainModel(), braintools.optim.Adam(lr=0.2), loss_fn=loss_fn)
+   result = fitter.fit(n_steps=40)
+   print(f"custom loss: fitted k = {float(result.best_params['k']):.1f}")
+
+
+Reading the Result
+------------------
+
+:meth:`~brainmass.Fitter.fit` returns a :class:`~brainmass.FitResult`:
+
+- ``best_loss`` -- the lowest loss seen,
+- ``best_params`` -- ``{name: value}`` in constrained (physical) space,
+- ``history`` -- per-iteration loss,
+- ``prediction`` -- the model output at the best point,
+- ``model`` -- the model, left holding the best-seen parameters,
+- ``optimizer`` / ``raw`` -- the underlying optimizer and its native result.
+
+Callbacks (``callbacks=[fn]``, each called with ``{'step', 'loss', 'best_loss',
+'model'}``) can monitor progress and, by returning ``True``, stop the ``grad``
+backend early.
 
 
 Best Practices
 --------------
 
-1. **Start Simple**
-   - Fit one parameter at a time initially
-   - Add complexity gradually
-
-2. **Use Multiple Initializations**
-   - Run optimization from different starting points
-   - Avoid local minima
-
-3. **Normalize Loss**
-   - Scale loss components to similar magnitude
-   - Prevents one term dominating
-
-4. **Validate on Hold-Out Data**
-   - Test fitted parameters on unseen data
-   - Check for overfitting
-
-5. **Monitor Convergence**
-   - Plot loss vs iteration
-   - Stop when loss plateaus
-
-6. **Set Reasonable Bounds**
-   - Use prior knowledge for parameter ranges
-   - Prevents unphysical values
-
-
-Common Issues
--------------
-
-**Optimization Stuck in Local Minimum:**
-
-- Use global optimizer (Nevergrad)
-- Try multiple initializations
-- Increase budget
-
-**Loss Not Decreasing:**
-
-- Check loss function implementation
-- Verify simulation is correct
-- Reduce learning rate (gradient-based)
-
-**Parameters Unrealistic:**
-
-- Add constraints/bounds
-- Use regularization
-- Check units
-
-**Slow Optimization:**
-
-- Reduce simulation time
-- Use simpler model for initial fits
-- Parallelize evaluations (Nevergrad supports this)
-
-
-Complete Example
-----------------
-
-Full FC-Based Parameter Fitting
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-   import brainmass
-   import jax.numpy as jnp
-   import brainstate
-   import nevergrad as ng
-
-   # Load data
-   SC = jnp.load('SC_AAL90.npy')
-   FC_emp = jnp.load('FC_empirical.npy')
-
-   # Simulation function
-   def simulate_bold_fc(coupling_k, noise_sigma):
-       N = 90
-       T = 600000  # 10 min at 1ms
-
-       # Create network
-       nodes = brainmass.WongWangStep(in_size=N)
-       coupling = brainmass.DiffusiveCoupling(conn=SC, k=coupling_k)
-       nodes.noise_E = brainmass.OUProcess(
-           in_size=N,
-           sigma=noise_sigma,
-           tau=100.0,
-       )
-       bold = brainmass.BOLDSignal(in_size=N)
-
-       # Initialize
-       nodes.init_all_states()
-       coupling.init_all_states()
-       bold.init_all_states()
-
-       # Simulate
-       neural_ts = []
-       for t in range(T):
-           S_E = nodes.S_E.value
-           coupled = coupling(S_E, S_E)
-           out = nodes.update(S_E_ext=coupled)
-           neural_ts.append(out)
-
-           if t % 10000 == 0:
-               print(f"  Sim: {t}/{T}")
-
-       neural_ts = jnp.stack(neural_ts)
-
-       # BOLD
-       bold_ts = []
-       for z in neural_ts:
-           bold.update(z=z)
-           bold_ts.append(bold.bold())
-
-       bold_downsampled = jnp.stack(bold_ts)[::2000]
-
-       # FC
-       FC_sim = jnp.corrcoef(bold_downsampled.T)
-
-       return FC_sim
-
-   # Loss function
-   def objective(coupling_k, noise_sigma):
-       print(f"Trying k={coupling_k:.3f}, sigma={noise_sigma:.4f}")
-
-       FC_sim = simulate_bold_fc(coupling_k, noise_sigma)
-       corr = jnp.corrcoef(FC_sim.flatten(), FC_emp.flatten())[0, 1]
-       loss = 1.0 - corr
-
-       print(f"  Loss: {loss:.4f}, FC corr: {corr:.4f}")
-       return loss
-
-   # Optimization
-   instrum = ng.p.Instrumentation(
-       coupling_k=ng.p.Scalar(init=0.2, lower=0.0, upper=1.0),
-       noise_sigma=ng.p.Scalar(init=0.01, lower=0.0, upper=0.1),
-   )
-
-   optimizer = ng.optimizers.NGOpt(parametrization=instrum, budget=50)
-
-   for i in range(50):
-       print(f"\n=== Iteration {i+1}/50 ===")
-       x = optimizer.ask()
-       loss = objective(**x.kwargs)
-       optimizer.tell(x, loss)
-
-   # Best result
-   best = optimizer.provide_recommendation()
-   print(f"\nBest parameters:")
-   print(f"  Coupling k: {best.kwargs['coupling_k']:.3f}")
-   print(f"  Noise sigma: {best.kwargs['noise_sigma']:.4f}")
-
-
-Next Steps
-----------
-
-- Try parameter fitting on your own data
-- Explore different loss functions
-- Compare optimization methods
-- :doc:`../examples/index` for advanced optimization examples
+1. **Constrain with transforms.** A ``SigmoidT`` / ``SoftplusT`` parameter cannot
+   leave its physical range, and its bounds double as the gradient-free search box.
+2. **Start simple.** Fit one or two scalar parameters before a full matrix; the
+   gradient-free backends evaluate candidates one at a time and suit low dimensions.
+3. **Normalise the loss.** Scale objective terms to similar magnitudes (see
+   :func:`brainmass.objectives.combine`) so one term does not dominate.
+4. **Discard transients.** Pass ``transient=<n_samples>`` to drop warm-up samples
+   from the prediction before the objective is applied.
+5. **Swap backends to escape local minima.** Try a gradient-free global search
+   (Nevergrad) when gradient descent stalls, then refine with ``grad``.
 
 
 See Also
 --------
 
-- :doc:`forward_modeling` - Getting observable data from models
-- Nevergrad documentation
-- Optax documentation
+- :doc:`forward_modeling` - getting observable data out of models
+- :doc:`building_networks` - building the whole-brain models you fit
+- :class:`brainmass.Simulator` - the run loop behind ``predict``
+- :mod:`brainmass.objectives` - the objective builders

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,7 @@ pytest-cov
 coverage
 absl-py
 matplotlib
+# Fitter's gradient-free backend (braintools.optim.NevergradOptimizer) needs
+# nevergrad; it is only a braintools "testing" extra, so install it explicitly
+# for the brainmass test suite and the doctest examples.
+nevergrad


### PR DESCRIPTION
Consolidate the 7 copy-pasted ModelFitting classes into a single reusable
`brainmass.Fitter` (+ `FitResult`): write the objective once, swap the
optimizer backend.

- grad (optax): the canonical loop verbatim — states(ParamState) ->
  register_trainable_weights -> jitted grad(has_aux, return_value) ->
  optimizer.step, with param_precompute(), automatic reg_loss(), and a
  best-seen checkpoint. Reproduces a hand-rolled ModelFitting loop step
  for step (asserted in tests).
- nevergrad / scipy: search a bounded search_space derived from each
  Param transform (SigmoidT/TanhT/Softsign/ScaledSigmoid/Clip give a finite
  box; half-line/unbounded transforms require an explicit bound). Candidates
  are set via Param.set_value and looped (vmap over set_value is unsupported).
- Shared: user predict(model) Simulator closure + objectives objective, or a
  custom loss_fn(model)->(loss, aux); transient trimming; callbacks/early-stop
  (grad); fitter.optimizer exposed.

Migrate docs/tutorials/parameter_fitting.rst to a runnable, all-backends
worked example; add Fitter/FitResult to docs/apis/orchestration.rst. Add
nevergrad to requirements-dev.txt (braintools ships it only as a testing
extra) and importorskip-guard the nevergrad tests.

Tests: 36 new cases (all 3 backends reduce loss, grad==hand-rolled, FCD
objective, search-space derivation, constrained round-trip, callbacks/
early-stop, custom loss, and every edge-case error). Full suite 439 passed.
