### PR TITLE
feat: nonlinear couplings (sigmoidal, tanh, Jansen-Rit) + additive bias (goal-11)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -568,3 +568,61 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
   Epileptor, Larter-Breakspear, Coombes-Byrne (complex, goal-09) · Generic2dOscillator,
   WongWang-ExcInh, Lorenz, Linear (canonical/E-I, goal-10). brainmass additionally has HORN + forward
   models (BOLD/EEG/MEG lead fields) with no tvboptim equivalent.
+
+### 2026-06-19 · goal-11 coupling-parity
+
+- **Closed coupling parity with tvboptim** — three nonlinear `function + Module` pairs added to
+  `coupling.py`, mirroring the existing kernel+thin-Module pattern exactly (no new base class):
+  - **`sigmoidal_coupling` / `SigmoidalCoupling`** (TVB *Sigmoidal*, **post**-nonlinearity):
+    `c = k·σ(slope·(a·Σ_j w_ij x_j + b − midpoint))`, defaults `k=1,a=1,b=0,slope=1,midpoint=0`.
+  - **`hyperbolic_tangent_coupling` / `HyperbolicTangentCoupling`** (TVB *HyperbolicTangent*, **post**):
+    `c = k·tanh(scale·Σ_j w_ij x_j)`, defaults `k=0.5,scale=2.0`; saturates to `±k`.
+  - **`sigmoidal_jansen_rit_coupling` / `SigmoidalJansenRitCoupling`** (TVB *SigmoidalJansenRit*,
+    **pre**-nonlinearity): `c = k·Σ_j w_ij·σ_JR(x_j)`, `σ_JR(x)=cmin+(cmax−cmin)/(1+e^{r(midpoint−x)})`,
+    defaults `k=1,cmin=0,cmax=0.005,midpoint=6.0,r=0.56`. Source `x_j` is whatever the caller
+    prefetches (e.g. JR `y1−y2`).
+  - **Linear bias** added to `additive_coupling`/`AdditiveCoupling`: `c = k·Σ_j w_ij x_j + b`
+    (default `b=0.0`).
+- **`G ≡ k` convention:** brainmass keeps `k` for the global strength; tvboptim/TVB call it `G`.
+  Documented `G ≡ k` in every new docstring + the docs page note. New trainable scalars
+  (`slope`,`midpoint`,`cmin`,`cmax`,`r`,`a`,`b`) all go through `Param.init`.
+- **pre- vs post-nonlinearity split is the key design axis:** post-forms (sigmoid/tanh) apply the
+  saturating fn to the *summed* network input → output carries `k`'s unit; the JR pre-form applies
+  σ_JR to each *source* before weighting → output carries `k·conn`'s unit (σ is dimensionless).
+- **Back-compat win — `Param.init(float)` returns a `Const`, NOT a trainable `ParamState`.** So the
+  new default `b=0.0` (and all new default scalars) add **zero** trainable params — goal-08 Fitter's
+  `states(ParamState)` is unaffected. Trainable only when the caller passes an explicit `Param(...)`.
+  Confirmed: `m.states(ParamState)` lists only explicit `Param`s, never `Param.init(float)` Consts.
+- **`Quantity(nA) + 0.0` does NOT raise in brainunit** (treats `+0.0` as the additive identity),
+  so `additive_coupling`'s new `+ b` is **bit-for-bit** identical for both dimensionless and
+  unit-carrying coupling at the default — no gating needed. Verified `np.array_equal` (b=0 == old).
+- **Nonlinear kernels strip units for the transcendental** via `u.get_magnitude` on the σ/tanh
+  argument (`u.math.tanh`/`sigmoid` raise on a unitful Quantity) — same house style as Jansen-Rit.
+  Output units come back via the `k *` (post) / `k * (conn * σ)` (pre) multiply.
+- **conn handling for the new (additive-style, no target `y`) couplings:** shared helper
+  `_coupling_conn_xmat` accepts 2-D `(N_out,N_in)` **or** a 1-D **square**-flattened `(N*N,)` conn
+  (infers `n=isqrt(size)`; non-square 1-D raises — there's no `y` to disambiguate `N_out`, unlike
+  `diffusive_coupling`). `additive_coupling` kept its 2-D-only body untouched (back-compat); only
+  appended `+ b`.
+- **Network integration:** extended `Network`'s `coupling=` dispatch with `'sigmoidal'`/`'tanh'`/
+  `'sigmoidal_jansen_rit'` (each plugs the delayed `(N,N)` `src` read into the new Module exactly
+  like `AdditiveCoupling`). 2-node `HopfStep` nets run clean under `Simulator` (instantaneous + with
+  `distance/speed` delays). ⚠ `Network.__init__` calls `prefetch_delay`, which reads `dt` from
+  `environ` **at construction time** — tests must `environ.set(dt=…)` *before* building the Network
+  (the docstring example relies on `doctest_global_setup`'s `dt`).
+- **No tvboptim reference-regression test was added.** tvboptim isn't importable in this env, and the
+  goal-10 user override ("remove TVB/TVBOPTIM comparison tests") removed the gating machinery from
+  earlier goals; tvboptim's coupling math is plain-array identical to ours, so the **closed-form
+  oracles are the gate** (sigmoid@0 input `=k·σ(−slope·midpoint)`; tanh→`±k`; σ_JR@midpoint
+  `=k·Σw·(cmin+cmax)/2`, far-limits → `cmin`/`cmax`). If a future goal wants live regression: match
+  weights/params and `allclose` (tvboptim `Bunch(G,a,b,slope,midpoint)` / `Bunch(G,cmin,cmax,
+  midpoint,r)` map 1:1 to our kwargs, `G→k`).
+- **Coverage:** `coupling.py` 95.93% / `network.py` 100% (the new helper + 3 kernels + 3 Modules +
+  bias are **100%** covered; the 6 residual `coupling.py` misses are *pre-existing* diffusive/additive
+  guards + laplacian's unknown-normalize raise). Full suite **552 → 558 passed** (24 new coupling
+  tests incl. closed-form, gradient-FD on k/slope/midpoint/b, units, batched, 1-D-flattened-conn &
+  flattened-x, delayed-source-via-Network, constrained-`Param` round-trip). Local doctest via
+  `DocTestFinder().find()` = 24/24 (the reliable check; `--doctest-modules` mis-filters re-exports).
+- **Deferred (candidate follow-ons):** `KuramotoCoupling` (phase coupling `k·Σ w_ij·sin(θ_j−θ_i)`)
+  and the hierarchical `SubspaceCoupling` (per-subpopulation coupling) — both out of scope here;
+  observation models are goal-12. No new `Delayed*` twins (delays stay upstream via `prefetch_delay`).

--- a/brainmass/__init__.py
+++ b/brainmass/__init__.py
@@ -25,8 +25,14 @@ from ._xy_model import (
 from .coupling import (
     DiffusiveCoupling,
     AdditiveCoupling,
+    SigmoidalCoupling,
+    HyperbolicTangentCoupling,
+    SigmoidalJansenRitCoupling,
     diffusive_coupling,
     additive_coupling,
+    sigmoidal_coupling,
+    hyperbolic_tangent_coupling,
+    sigmoidal_jansen_rit_coupling,
     laplacian_connectivity,
     LaplacianConnParam,
 )
@@ -178,8 +184,14 @@ __all__ = [
     # Coupling mechanisms
     'DiffusiveCoupling',
     'AdditiveCoupling',
+    'SigmoidalCoupling',
+    'HyperbolicTangentCoupling',
+    'SigmoidalJansenRitCoupling',
     'diffusive_coupling',
     'additive_coupling',
+    'sigmoidal_coupling',
+    'hyperbolic_tangent_coupling',
+    'sigmoidal_jansen_rit_coupling',
     'laplacian_connectivity',
     'LaplacianConnParam',
 

--- a/brainmass/coupling.py
+++ b/brainmass/coupling.py
@@ -43,8 +43,14 @@ Array = brainstate.typing.ArrayLike
 __all__ = [
     'DiffusiveCoupling',
     'AdditiveCoupling',
+    'SigmoidalCoupling',
+    'HyperbolicTangentCoupling',
+    'SigmoidalJansenRitCoupling',
     'diffusive_coupling',
     'additive_coupling',
+    'sigmoidal_coupling',
+    'hyperbolic_tangent_coupling',
+    'sigmoidal_jansen_rit_coupling',
     'laplacian_connectivity',
     'LaplacianConnParam',
 ]
@@ -54,6 +60,72 @@ def _check_type(x):
     if not (isinstance(x, _PREFETCH_TYPES) or callable(x)):
         raise TypeError(f'The argument must be a Prefetch or Callable, got {x}')
     return x
+
+
+def _coupling_conn_xmat(delayed_x: Callable | Array, conn: Array):
+    r"""Resolve ``(conn2d, x_mat)`` for additive-style couplings (no target ``y``).
+
+    Shared shape machinery for the post-/pre-nonlinearity couplings, which weight
+    a source signal by a connectivity matrix and sum over the source axis. Unlike
+    :func:`diffusive_coupling`, there is no target signal to infer ``N_out`` from,
+    so a flattened ``conn`` is assumed **square** (``N_out == N_in``).
+
+    Parameters
+    ----------
+    delayed_x : Callable or ArrayLike
+        Zero-arg callable (e.g. a ``Prefetch`` / ``prefetch_delay``) or array
+        returning the source signal, shaped ``(..., N_out, N_in)`` or flattened
+        ``(..., N_out * N_in)``.
+    conn : ArrayLike
+        Connection weights, either ``(N_out, N_in)`` or square-flattened
+        ``(N_out * N_in,)`` with ``N_out == N_in``.
+
+    Returns
+    -------
+    conn2d : ArrayLike
+        The ``(N_out, N_in)`` connection matrix.
+    x_mat : ArrayLike
+        The source signal reshaped to ``(..., N_out, N_in)``.
+
+    Raises
+    ------
+    ValueError
+        If ``conn`` is neither 1-D (square) nor 2-D, a flattened ``conn`` is not a
+        perfect square, or ``x`` is incompatible with ``(..., N_out, N_in)``.
+    """
+    x_val = delayed_x() if callable(delayed_x) else delayed_x
+    if x_val.ndim < 1:
+        raise ValueError(f'x must have at least 1 dimension; got shape {x_val.shape}')
+
+    if conn.ndim == 2:
+        n_out, n_in = conn.shape
+        conn2d = conn
+    elif conn.ndim == 1:
+        n = int(round(float(np.sqrt(conn.size))))
+        if n * n != conn.size:
+            raise ValueError(
+                f'Flattened conn length {conn.size} is not a perfect square; these '
+                f'couplings have no target to infer N_out, so a 1-D conn must be '
+                f'square (N_out == N_in). Pass a 2-D (N_out, N_in) conn for '
+                f'non-square connectivity.'
+            )
+        n_out = n_in = n
+        conn2d = u.math.reshape(conn, (n, n))
+    else:
+        raise ValueError(
+            f'conn must be 1-D (square-flattened) or 2-D; got {conn.ndim}-D.'
+        )
+
+    if x_val.ndim >= 2 and x_val.shape[-2:] == (n_out, n_in):
+        x_mat = x_val
+    elif x_val.shape[-1] == n_out * n_in:
+        x_mat = u.math.reshape(x_val, (*x_val.shape[:-1], n_out, n_in))
+    else:
+        raise ValueError(
+            f'x has incompatible shape {x_val.shape}; expected (..., {n_out}, {n_in}) '
+            f'or flattened (..., {n_out * n_in}).'
+        )
+    return conn2d, x_mat
 
 
 @set_module_as('brainmass')
@@ -207,16 +279,19 @@ class DiffusiveCoupling(Module):
 def additive_coupling(
     delayed_x: Callable | Array,
     conn: Array,
-    k: Array = 1.0
+    k: Array = 1.0,
+    b: Array = 0.0,
 ):
     r"""
-    Additive coupling kernel (function form).
+    Additive (linear) coupling kernel (function form).
 
     Computes, for each target unit i over the last axis, the additive term
 
-        current_i = k * sum_j conn[i, j] * x_{i, j}
+        current_i = k * sum_j conn[i, j] * x_{i, j} + b
 
     with full support for leading batch/time dimensions and unit-safe algebra.
+    This is TVB's ``Linear`` coupling; the global coupling strength ``k`` is TVB's
+    ``G`` (``G ≡ k``) and ``b`` is its offset/bias.
 
     Parameters
     ----------
@@ -226,7 +301,12 @@ def additive_coupling(
     conn : ArrayLike
         Connection weights with shape ``(N_out, N_in)``.
     k : ArrayLike
-        Global coupling strength. Scalar or broadcastable to ``(..., N_out)``.
+        Global coupling strength (TVB ``G``). Scalar or broadcastable to ``(..., N_out)``.
+    b : ArrayLike, default 0.0
+        Additive offset/bias, added after the weighted sum. The default ``0.0`` is
+        the additive identity, so it reproduces the bias-free coupling bit-for-bit
+        (and, by brainunit's convention, does not disturb a unit-carrying output).
+        A non-zero ``b`` should carry the same units as ``k * sum_j conn x``.
 
     Returns
     -------
@@ -238,6 +318,16 @@ def additive_coupling(
     ------
     ValueError
         If shapes are incompatible with the expected conventions.
+
+    Examples
+    --------
+    >>> import brainmass
+    >>> import jax.numpy as jnp
+    >>> conn = jnp.ones((2, 2))
+    >>> x = jnp.array([[1.0, 2.0], [3.0, 4.0]])
+    >>> out = brainmass.additive_coupling(x, conn, k=1.0, b=0.5)
+    >>> [float(v) for v in out]
+    [3.5, 7.5]
     """
     # x expected trailing dims to match connection (N_out, N_in) or flattened N_out*N_in
     x_val = delayed_x() if callable(delayed_x) else delayed_x
@@ -254,24 +344,28 @@ def additive_coupling(
         )
 
     additive = conn * x_mat  # broadcasting on leading dims
-    return k * additive.sum(axis=-1)  # (..., N_out)
+    return k * additive.sum(axis=-1) + b  # (..., N_out); b=0.0 is the identity
 
 
 class AdditiveCoupling(Module):
     r"""
-    Additive coupling.
+    Additive (linear) coupling.
 
     This class implements an additive coupling mechanism for neural network modules.
     It simulates the following model:
 
     $$
-    \mathrm{current}_i = k * \sum_j g_{ij} * x_{D_{ij}}
+    \mathrm{current}_i = k * \sum_j g_{ij} * x_{D_{ij}} + b
     $$
 
     where:
         - $\mathrm{current}_i$: the output current for neuron $i$
         - $g_{ij}$: the connection strength between neuron $i$ and neuron $j$
         - $x_{D_{ij}}$: the delayed state variable for neuron $j$, as seen by neuron $i$
+        - $b$: an additive offset/bias
+
+    This is TVB's ``Linear`` coupling; the global strength ``k`` is TVB's ``G``
+    (``G ≡ k``).
 
     Parameters
     ----------
@@ -281,6 +375,11 @@ class AdditiveCoupling(Module):
         The connection matrix (1D or 2D array) specifying the coupling strengths between units.
     k: Param, array_like
         The global coupling strength. Default is 1.0.
+    b: Param, array_like
+        Additive offset/bias added after the weighted sum. Default is ``0.0``, which
+        reproduces the bias-free coupling bit-for-bit. Pass a trainable ``Param`` to
+        fit it (``Param.init(0.0)`` yields a non-trainable ``Const``, so the default
+        adds no trainable state).
 
     """
     __module__ = 'brainmass'
@@ -289,13 +388,16 @@ class AdditiveCoupling(Module):
         self,
         x: Prefetch,
         conn: Parameter,
-        k: Parameter = 1.0
+        k: Parameter = 1.0,
+        b: Parameter = 0.0,
     ):
         super().__init__()
         self.x = _check_type(x)
 
         # global coupling strength
         self.k = Param.init(k)
+        # additive offset/bias (b=0.0 -> Const, no trainable state added)
+        self.b = Param.init(b)
 
         # Connection matrix
         self.conn = Param.init(conn)
@@ -308,7 +410,457 @@ class AdditiveCoupling(Module):
         init_maybe_prefetch(self.x)
 
     def update(self, *args, **kwargs):
-        return additive_coupling(self.x, self.conn.value(), self.k.value())
+        return additive_coupling(
+            self.x, self.conn.value(), self.k.value(), self.b.value()
+        )
+
+
+@set_module_as('brainmass')
+def sigmoidal_coupling(
+    delayed_x: Callable | Array,
+    conn: Array,
+    k: Array = 1.0,
+    a: Array = 1.0,
+    b: Array = 0.0,
+    slope: Array = 1.0,
+    midpoint: Array = 0.0,
+):
+    r"""
+    Sigmoidal coupling kernel (function form, post-nonlinearity).
+
+    The TVB ``Sigmoidal`` coupling: a logistic nonlinearity is applied **after** the
+    network sum, so each target's coupled input saturates smoothly,
+
+    .. math::
+
+        c_i = k \, \sigma\!\left(\mathrm{slope} \cdot
+              \left(a \sum_j w_{ij} x_j + b - \mathrm{midpoint}\right)\right),
+        \qquad \sigma(z) = \frac{1}{1 + e^{-z}}.
+
+    Parameters
+    ----------
+    delayed_x : Callable or ArrayLike
+        Zero-arg callable (e.g. a ``Prefetch`` / ``prefetch_delay``) or array
+        returning the source signal, shaped ``(..., N_out, N_in)`` or flattened
+        ``(..., N_out * N_in)``.
+    conn : ArrayLike
+        Connection weights, ``(N_out, N_in)`` or square-flattened ``(N_out * N_in,)``.
+    k : ArrayLike, default 1.0
+        Global coupling strength (TVB ``G``; ``G ≡ k``). Scales the saturated output.
+    a : ArrayLike, default 1.0
+        Linear scaling of the network sum before the sigmoid.
+    b : ArrayLike, default 0.0
+        Linear offset added to the network sum before the sigmoid.
+    slope : ArrayLike, default 1.0
+        Steepness of the logistic nonlinearity.
+    midpoint : ArrayLike, default 0.0
+        Centre of the logistic nonlinearity.
+
+    Returns
+    -------
+    ArrayLike
+        Coupling output with shape ``(..., N_out)``. The logistic is dimensionless,
+        so the output carries the units of ``k``.
+
+    See Also
+    --------
+    hyperbolic_tangent_coupling : symmetric (``tanh``) post-nonlinearity.
+    sigmoidal_jansen_rit_coupling : pre-nonlinearity Jansen-Rit sigmoid.
+    additive_coupling : the underlying linear (``k * sum + b``) coupling.
+
+    Notes
+    -----
+    The argument of the logistic must be dimensionless; the network sum is reduced
+    to its magnitude (``brainunit.get_magnitude``) before the nonlinearity, mirroring
+    the Jansen-Rit house style. At zero net input the output is
+    ``k * sigma(slope * (b - midpoint))`` (``= k * sigma(-slope * midpoint)`` for the
+    default ``a = 1, b = 0``).
+
+    References
+    ----------
+    .. [1] Sanz-Leon, P., Knock, S. A., Spiegler, A., & Jirsa, V. K. (2015).
+           Mathematical framework for large-scale brain network modeling in The
+           Virtual Brain. NeuroImage, 111, 385-430.
+
+    Examples
+    --------
+    >>> import brainmass
+    >>> import jax.numpy as jnp
+    >>> conn = jnp.ones((2, 2))
+    >>> x = jnp.zeros((2, 2))  # zero net input
+    >>> out = brainmass.sigmoidal_coupling(x, conn, k=1.0, slope=1.0, midpoint=0.0)
+    >>> [round(float(v), 3) for v in out]
+    [0.5, 0.5]
+    """
+    conn2d, x_mat = _coupling_conn_xmat(delayed_x, conn)
+    net = u.get_magnitude((conn2d * x_mat).sum(axis=-1))  # (..., N_out)
+    return k * u.math.sigmoid(slope * (a * net + b - midpoint))
+
+
+class SigmoidalCoupling(Module):
+    r"""
+    Sigmoidal coupling (TVB ``Sigmoidal``, post-nonlinearity).
+
+    Applies a logistic nonlinearity after the network sum:
+
+    $$
+    c_i = k \, \sigma\!\left(\mathrm{slope} \cdot
+          \left(a \sum_j g_{ij} x_{D_{ij}} + b - \mathrm{midpoint}\right)\right)
+    $$
+
+    where $\sigma$ is the logistic function and $g_{ij}$ the connection strength.
+    ``k`` is the global coupling strength (TVB ``G``; ``G ≡ k``).
+
+    Parameters
+    ----------
+    x : Prefetch, Callable
+        The (optionally delayed) source state, shaped ``(..., N_out, N_in)``.
+    conn : Param, array_like
+        Connection matrix ``(N_out, N_in)`` or square-flattened ``(N_out * N_in,)``.
+    k : Param, array_like, default 1.0
+        Global coupling strength (TVB ``G``).
+    a : Param, array_like, default 1.0
+        Linear scaling of the network sum before the sigmoid.
+    b : Param, array_like, default 0.0
+        Linear offset added before the sigmoid.
+    slope : Param, array_like, default 1.0
+        Steepness of the logistic.
+    midpoint : Param, array_like, default 0.0
+        Centre of the logistic.
+
+    See Also
+    --------
+    HyperbolicTangentCoupling : symmetric (``tanh``) post-nonlinearity.
+    SigmoidalJansenRitCoupling : pre-nonlinearity Jansen-Rit sigmoid.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        x: Prefetch,
+        conn: Parameter,
+        k: Parameter = 1.0,
+        a: Parameter = 1.0,
+        b: Parameter = 0.0,
+        slope: Parameter = 1.0,
+        midpoint: Parameter = 0.0,
+    ):
+        super().__init__()
+        self.x = _check_type(x)
+
+        self.k = Param.init(k)
+        self.a = Param.init(a)
+        self.b = Param.init(b)
+        self.slope = Param.init(slope)
+        self.midpoint = Param.init(midpoint)
+
+        self.conn = Param.init(conn)
+        ndim = self.conn.value().ndim
+        if ndim not in (1, 2):
+            raise ValueError(
+                f'Connection must be 1D (square-flattened) or 2D matrix; got {ndim}D.'
+            )
+
+    @brainstate.nn.call_order(2)
+    def init_state(self, *args, **kwargs):
+        init_maybe_prefetch(self.x)
+
+    def update(self, *args, **kwargs):
+        return sigmoidal_coupling(
+            self.x, self.conn.value(), self.k.value(), self.a.value(),
+            self.b.value(), self.slope.value(), self.midpoint.value(),
+        )
+
+
+@set_module_as('brainmass')
+def hyperbolic_tangent_coupling(
+    delayed_x: Callable | Array,
+    conn: Array,
+    k: Array = 0.5,
+    scale: Array = 2.0,
+):
+    r"""
+    Hyperbolic-tangent coupling kernel (function form, post-nonlinearity).
+
+    The TVB ``HyperbolicTangent`` coupling: a symmetric saturating nonlinearity is
+    applied **after** the network sum,
+
+    .. math::
+
+        c_i = k \, \tanh\!\left(\mathrm{scale} \sum_j w_{ij} x_j\right).
+
+    Parameters
+    ----------
+    delayed_x : Callable or ArrayLike
+        Zero-arg callable (e.g. a ``Prefetch`` / ``prefetch_delay``) or array
+        returning the source signal, shaped ``(..., N_out, N_in)`` or flattened
+        ``(..., N_out * N_in)``.
+    conn : ArrayLike
+        Connection weights, ``(N_out, N_in)`` or square-flattened ``(N_out * N_in,)``.
+    k : ArrayLike, default 0.5
+        Global coupling strength (TVB ``G``; ``G ≡ k``). The output saturates to
+        ``±k``.
+    scale : ArrayLike, default 2.0
+        Scaling of the network sum before the ``tanh``.
+
+    Returns
+    -------
+    ArrayLike
+        Coupling output with shape ``(..., N_out)``. ``tanh`` is dimensionless, so the
+        output carries the units of ``k``.
+
+    See Also
+    --------
+    sigmoidal_coupling : asymmetric (logistic) post-nonlinearity.
+    additive_coupling : the underlying linear coupling.
+
+    Notes
+    -----
+    The argument of ``tanh`` must be dimensionless; the network sum is reduced to its
+    magnitude (``brainunit.get_magnitude``) before the nonlinearity. As ``|sum| → ∞``
+    the output saturates to ``±k``.
+
+    References
+    ----------
+    .. [1] Sanz-Leon, P., Knock, S. A., Spiegler, A., & Jirsa, V. K. (2015).
+           Mathematical framework for large-scale brain network modeling in The
+           Virtual Brain. NeuroImage, 111, 385-430.
+
+    Examples
+    --------
+    >>> import brainmass
+    >>> import jax.numpy as jnp
+    >>> conn = jnp.ones((2, 2))
+    >>> x = jnp.full((2, 2), 1e3)  # large positive net input saturates to +k
+    >>> out = brainmass.hyperbolic_tangent_coupling(x, conn, k=0.5, scale=2.0)
+    >>> [round(float(v), 3) for v in out]
+    [0.5, 0.5]
+    """
+    conn2d, x_mat = _coupling_conn_xmat(delayed_x, conn)
+    net = u.get_magnitude((conn2d * x_mat).sum(axis=-1))  # (..., N_out)
+    return k * u.math.tanh(scale * net)
+
+
+class HyperbolicTangentCoupling(Module):
+    r"""
+    Hyperbolic-tangent coupling (TVB ``HyperbolicTangent``, post-nonlinearity).
+
+    Applies a symmetric saturating nonlinearity after the network sum:
+
+    $$
+    c_i = k \, \tanh\!\left(\mathrm{scale} \sum_j g_{ij} x_{D_{ij}}\right)
+    $$
+
+    where $g_{ij}$ is the connection strength. ``k`` is the global coupling strength
+    (TVB ``G``; ``G ≡ k``) and the output saturates to $\pm k$.
+
+    Parameters
+    ----------
+    x : Prefetch, Callable
+        The (optionally delayed) source state, shaped ``(..., N_out, N_in)``.
+    conn : Param, array_like
+        Connection matrix ``(N_out, N_in)`` or square-flattened ``(N_out * N_in,)``.
+    k : Param, array_like, default 0.5
+        Global coupling strength (TVB ``G``).
+    scale : Param, array_like, default 2.0
+        Scaling of the network sum before the ``tanh``.
+
+    See Also
+    --------
+    SigmoidalCoupling : asymmetric (logistic) post-nonlinearity.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        x: Prefetch,
+        conn: Parameter,
+        k: Parameter = 0.5,
+        scale: Parameter = 2.0,
+    ):
+        super().__init__()
+        self.x = _check_type(x)
+
+        self.k = Param.init(k)
+        self.scale = Param.init(scale)
+
+        self.conn = Param.init(conn)
+        ndim = self.conn.value().ndim
+        if ndim not in (1, 2):
+            raise ValueError(
+                f'Connection must be 1D (square-flattened) or 2D matrix; got {ndim}D.'
+            )
+
+    @brainstate.nn.call_order(2)
+    def init_state(self, *args, **kwargs):
+        init_maybe_prefetch(self.x)
+
+    def update(self, *args, **kwargs):
+        return hyperbolic_tangent_coupling(
+            self.x, self.conn.value(), self.k.value(), self.scale.value()
+        )
+
+
+@set_module_as('brainmass')
+def sigmoidal_jansen_rit_coupling(
+    delayed_x: Callable | Array,
+    conn: Array,
+    k: Array = 1.0,
+    cmin: Array = 0.0,
+    cmax: Array = 0.005,
+    midpoint: Array = 6.0,
+    r: Array = 0.56,
+):
+    r"""
+    Sigmoidal Jansen-Rit coupling kernel (function form, pre-nonlinearity).
+
+    The TVB ``SigmoidalJansenRit`` coupling: the sigmoid is applied to each source
+    **before** the network sum (a firing-rate transfer of the presynaptic potential),
+
+    .. math::
+
+        c_i = k \sum_j w_{ij} \, \sigma_{\mathrm{JR}}(x_j),
+        \qquad
+        \sigma_{\mathrm{JR}}(x) = c_{\min}
+        + \frac{c_{\max} - c_{\min}}{1 + e^{\,r\,(\mathrm{midpoint} - x)}}.
+
+    The source ``x_j`` is whatever the caller prefetches -- e.g. the Jansen-Rit
+    ``y1 - y2`` pyramidal input.
+
+    Parameters
+    ----------
+    delayed_x : Callable or ArrayLike
+        Zero-arg callable (e.g. a ``Prefetch`` / ``prefetch_delay``) or array
+        returning the presynaptic source, shaped ``(..., N_out, N_in)`` or flattened
+        ``(..., N_out * N_in)``.
+    conn : ArrayLike
+        Connection weights, ``(N_out, N_in)`` or square-flattened ``(N_out * N_in,)``.
+    k : ArrayLike, default 1.0
+        Global coupling strength (TVB ``G``; ``G ≡ k``).
+    cmin : ArrayLike, default 0.0
+        Lower asymptote of the sigmoid (firing rate as ``x → -∞``).
+    cmax : ArrayLike, default 0.005
+        Upper asymptote of the sigmoid (firing rate as ``x → +∞``).
+    midpoint : ArrayLike, default 6.0
+        Half-activation potential (centre of the sigmoid).
+    r : ArrayLike, default 0.56
+        Steepness of the sigmoid.
+
+    Returns
+    -------
+    ArrayLike
+        Coupling output with shape ``(..., N_out)``. ``σ_JR`` is dimensionless, so the
+        output carries the units of ``k * conn``.
+
+    See Also
+    --------
+    sigmoidal_coupling : post-nonlinearity (sigmoid after the sum).
+    brainmass.JansenRitStep : the Jansen-Rit neural mass whose output this couples.
+
+    Notes
+    -----
+    The sigmoid argument must be dimensionless; the source is reduced to its magnitude
+    (``brainunit.get_magnitude``) before the nonlinearity. At ``x = midpoint`` the
+    transfer equals ``(cmin + cmax) / 2``, so ``c_i = k * (cmin + cmax) / 2 * Σ_j
+    w_ij``; far below/above ``midpoint`` it tends to ``cmin`` / ``cmax`` respectively.
+
+    References
+    ----------
+    .. [1] Jansen, B. H., & Rit, V. G. (1995). Electroencephalogram and visual evoked
+           potential generation in a mathematical model of coupled cortical columns.
+           Biological Cybernetics, 73(4), 357-366.
+
+    Examples
+    --------
+    >>> import brainmass
+    >>> import jax.numpy as jnp
+    >>> conn = jnp.array([[0.2, 0.3], [0.5, 0.1]])
+    >>> x = jnp.full((2, 2), 6.0)  # at the midpoint -> sigma = (cmin + cmax) / 2
+    >>> out = brainmass.sigmoidal_jansen_rit_coupling(x, conn, k=1.0)
+    >>> [round(float(v), 6) for v in out]
+    [0.00125, 0.0015]
+    """
+    conn2d, x_mat = _coupling_conn_xmat(delayed_x, conn)
+    xmag = u.get_magnitude(x_mat)  # (..., N_out, N_in), dimensionless
+    sigma = cmin + (cmax - cmin) / (1.0 + u.math.exp(r * (midpoint - xmag)))
+    return k * (conn2d * sigma).sum(axis=-1)  # (..., N_out)
+
+
+class SigmoidalJansenRitCoupling(Module):
+    r"""
+    Sigmoidal Jansen-Rit coupling (TVB ``SigmoidalJansenRit``, pre-nonlinearity).
+
+    Applies the Jansen-Rit firing-rate sigmoid to each source **before** the network
+    sum:
+
+    $$
+    c_i = k \sum_j g_{ij} \, \sigma_{\mathrm{JR}}(x_{D_{ij}}),
+    \qquad
+    \sigma_{\mathrm{JR}}(x) = c_{\min}
+    + \frac{c_{\max} - c_{\min}}{1 + e^{\,r\,(\mathrm{midpoint} - x)}}.
+    $$
+
+    ``k`` is the global coupling strength (TVB ``G``; ``G ≡ k``). The source is
+    whatever the caller prefetches (e.g. the Jansen-Rit ``y1 - y2``).
+
+    Parameters
+    ----------
+    x : Prefetch, Callable
+        The (optionally delayed) presynaptic source, shaped ``(..., N_out, N_in)``.
+    conn : Param, array_like
+        Connection matrix ``(N_out, N_in)`` or square-flattened ``(N_out * N_in,)``.
+    k : Param, array_like, default 1.0
+        Global coupling strength (TVB ``G``).
+    cmin : Param, array_like, default 0.0
+        Lower asymptote of the sigmoid.
+    cmax : Param, array_like, default 0.005
+        Upper asymptote of the sigmoid.
+    midpoint : Param, array_like, default 6.0
+        Half-activation potential.
+    r : Param, array_like, default 0.56
+        Steepness of the sigmoid.
+
+    See Also
+    --------
+    SigmoidalCoupling : post-nonlinearity sigmoid.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        x: Prefetch,
+        conn: Parameter,
+        k: Parameter = 1.0,
+        cmin: Parameter = 0.0,
+        cmax: Parameter = 0.005,
+        midpoint: Parameter = 6.0,
+        r: Parameter = 0.56,
+    ):
+        super().__init__()
+        self.x = _check_type(x)
+
+        self.k = Param.init(k)
+        self.cmin = Param.init(cmin)
+        self.cmax = Param.init(cmax)
+        self.midpoint = Param.init(midpoint)
+        self.r = Param.init(r)
+
+        self.conn = Param.init(conn)
+        ndim = self.conn.value().ndim
+        if ndim not in (1, 2):
+            raise ValueError(
+                f'Connection must be 1D (square-flattened) or 2D matrix; got {ndim}D.'
+            )
+
+    @brainstate.nn.call_order(2)
+    def init_state(self, *args, **kwargs):
+        init_maybe_prefetch(self.x)
+
+    def update(self, *args, **kwargs):
+        return sigmoidal_jansen_rit_coupling(
+            self.x, self.conn.value(), self.k.value(), self.cmin.value(),
+            self.cmax.value(), self.midpoint.value(), self.r.value(),
+        )
 
 
 @set_module_as('brainmass')

--- a/brainmass/coupling_test.py
+++ b/brainmass/coupling_test.py
@@ -15,6 +15,7 @@
 
 import brainstate
 import brainunit as u
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -300,3 +301,470 @@ class TestSharedRecurrentConn:
         out = conn.update()
         assert out.shape == (4,)
         assert np.all(np.isfinite(np.asarray(out)))
+
+
+# ---------------------------------------------------------------------------
+# goal-11: nonlinear couplings (parity with tvboptim) + additive Linear bias
+# ---------------------------------------------------------------------------
+
+
+def _sigmoid(z):
+    return 1.0 / (1.0 + np.exp(-z))
+
+
+class TestAdditiveBias:
+    """Linear bias ``b`` added to additive coupling (back-compat: b=0 == old)."""
+
+    def test_kernel_b_zero_matches_old(self):
+        # Default b=0 must reproduce the bias-free additive kernel bit-for-bit.
+        conn = jnp.array([[1.0, 0.0, 1.0],
+                          [0.0, 1.0, 1.0]])
+        x = jnp.array([[1.0, 2.0, 3.0],
+                       [4.0, 5.0, 6.0]])
+        out0 = brainmass.additive_coupling(x, conn, k=2.0)
+        out_b0 = brainmass.additive_coupling(x, conn, k=2.0, b=0.0)
+        assert np.array_equal(np.asarray(out0), np.asarray(out_b0))
+
+    def test_kernel_b_shifts(self):
+        conn = jnp.array([[1.0, 1.0],
+                          [1.0, 1.0]])
+        x = jnp.array([[1.0, 2.0],
+                       [3.0, 4.0]])
+        base = brainmass.additive_coupling(x, conn, k=1.0)
+        shifted = brainmass.additive_coupling(x, conn, k=1.0, b=0.5)
+        assert u.math.allclose(shifted, base + 0.5)
+
+    def test_module_bias(self):
+        holder = _Holder()
+        holder.x = jnp.array([[1.0, 2.0, 3.0],
+                              [4.0, 5.0, 6.0]])
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        conn = jnp.array([[1.0, 0.0, 1.0],
+                          [0.0, 1.0, 1.0]])
+        coup = brainmass.AdditiveCoupling(x_ref, conn=conn, k=2.0, b=0.3)
+        coup.init_state()
+        out = coup.update()
+        exp = 2.0 * jnp.array([jnp.sum(conn[0] * holder.x[0]),
+                               jnp.sum(conn[1] * holder.x[1])]) + 0.3
+        assert u.math.allclose(out, exp)
+
+    def test_module_default_bias_backcompat(self):
+        # AdditiveCoupling with no b must equal the old behaviour exactly.
+        holder = _Holder()
+        holder.x = jnp.array([[1.0, 2.0, 3.0],
+                              [4.0, 5.0, 6.0]])
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        conn = jnp.array([[1.0, 0.0, 1.0],
+                          [0.0, 1.0, 1.0]])
+        coup = brainmass.AdditiveCoupling(x_ref, conn=conn, k=2.0)
+        coup.init_state()
+        out = coup.update()
+        exp = 2.0 * jnp.array([jnp.sum(conn[0] * holder.x[0]),
+                               jnp.sum(conn[1] * holder.x[1])])
+        assert np.array_equal(np.asarray(out), np.asarray(exp))
+
+    def test_unitful_default_bias_preserves_units(self):
+        # Unit-carrying additive coupling must still work with the default bias.
+        conn = jnp.array([[1.0, 1.0],
+                          [1.0, 1.0]])
+        x = jnp.array([[1.0, 2.0],
+                       [3.0, 4.0]]) * u.nA
+        out = brainmass.additive_coupling(x, conn, k=1.0)
+        assert u.get_unit(out) == u.nA
+        assert u.math.allclose(out, jnp.array([3.0, 7.0]) * u.nA)
+
+
+class TestSigmoidalCoupling:
+    """TVB Sigmoidal: post-nonlinearity c = k*sigma(slope*(a*sum + b - midpoint))."""
+
+    def test_closed_form_zero_input(self):
+        # Zero net input -> k*sigma(-slope*midpoint) (with a=1, b=0).
+        conn = jnp.ones((2, 2))
+        x = jnp.zeros((2, 2))
+        k, slope, midpoint = 0.7, 2.0, 3.0
+        out = brainmass.sigmoidal_coupling(
+            x, conn, k=k, slope=slope, midpoint=midpoint)
+        exp = k * _sigmoid(-slope * midpoint)
+        assert u.math.allclose(out, jnp.full((2,), exp), atol=1e-6)
+
+    def test_kernel_value(self):
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[1.0, 1.0],
+                       [2.0, 2.0]])  # row sums -> [2, 4]
+        out = brainmass.sigmoidal_coupling(x, conn, k=1.0, a=1.0, b=0.0,
+                                           slope=1.0, midpoint=0.0)
+        exp = _sigmoid(np.array([2.0, 4.0]))
+        assert u.math.allclose(out, jnp.asarray(exp), atol=1e-6)
+
+    def test_module_matches_kernel(self):
+        holder = _Holder()
+        holder.x = jnp.array([[0.5, 1.5],
+                              [-1.0, 2.0]])
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        conn = jnp.array([[1.0, 0.5],
+                          [0.5, 1.0]])
+        coup = brainmass.SigmoidalCoupling(x_ref, conn=conn, k=1.3, a=0.8,
+                                           b=0.1, slope=1.5, midpoint=0.2)
+        coup.init_state()
+        out = coup.update()
+        exp = brainmass.sigmoidal_coupling(holder.x, conn, k=1.3, a=0.8,
+                                           b=0.1, slope=1.5, midpoint=0.2)
+        assert out.shape == (2,)
+        assert u.math.allclose(out, exp)
+
+    def test_saturation_bounded(self):
+        # Sigmoid saturates in (0, k); huge |input| -> no NaN/Inf.
+        conn = jnp.ones((2, 2))
+        x_pos = jnp.full((2, 2), 1e6)
+        x_neg = jnp.full((2, 2), -1e6)
+        k = 2.0
+        out_pos = brainmass.sigmoidal_coupling(x_pos, conn, k=k, slope=1.0)
+        out_neg = brainmass.sigmoidal_coupling(x_neg, conn, k=k, slope=1.0)
+        assert np.all(np.isfinite(np.asarray(out_pos)))
+        assert np.all(np.isfinite(np.asarray(out_neg)))
+        assert u.math.allclose(out_pos, jnp.full((2,), k), atol=1e-5)
+        assert u.math.allclose(out_neg, jnp.zeros((2,)), atol=1e-5)
+
+    def test_batched(self):
+        batch = 4
+        conn = jnp.ones((2, 3))
+        x_single = jnp.array([[1.0, 0.0, -1.0],
+                              [2.0, 2.0, 2.0]])
+        x = jnp.broadcast_to(x_single, (batch, 2, 3))
+        out = brainmass.sigmoidal_coupling(x, conn, k=1.0)
+        exp_single = brainmass.sigmoidal_coupling(x_single, conn, k=1.0)
+        assert out.shape == (batch, 2)
+        assert u.math.allclose(out, jnp.broadcast_to(exp_single, (batch, 2)))
+
+    def test_flattened_conn_square(self):
+        conn2d = jnp.array([[1.0, 0.5],
+                            [0.5, 1.0]])
+        conn1d = conn2d.reshape(-1)
+        x = jnp.array([[1.0, 2.0],
+                       [3.0, 4.0]])
+        out2d = brainmass.sigmoidal_coupling(x, conn2d, k=1.0)
+        out1d = brainmass.sigmoidal_coupling(x, conn1d, k=1.0)
+        assert u.math.allclose(out2d, out1d)
+
+    def test_units_carry_k(self):
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[1.0, 1.0],
+                       [2.0, 2.0]])
+        out = brainmass.sigmoidal_coupling(x, conn, k=1.0 * u.nA)
+        assert u.get_unit(out) == u.nA
+
+
+class TestHyperbolicTangentCoupling:
+    """TVB HyperbolicTangent: post-nonlinearity c = k*tanh(scale*sum)."""
+
+    def test_saturation_pm_k(self):
+        conn = jnp.ones((2, 2))
+        k = 0.5
+        out_pos = brainmass.hyperbolic_tangent_coupling(
+            jnp.full((2, 2), 1e6), conn, k=k, scale=2.0)
+        out_neg = brainmass.hyperbolic_tangent_coupling(
+            jnp.full((2, 2), -1e6), conn, k=k, scale=2.0)
+        assert u.math.allclose(out_pos, jnp.full((2,), k), atol=1e-6)
+        assert u.math.allclose(out_neg, jnp.full((2,), -k), atol=1e-6)
+        assert np.all(np.isfinite(np.asarray(out_pos)))
+
+    def test_kernel_value(self):
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[0.1, 0.2],
+                       [0.3, 0.4]])  # row sums -> [0.3, 0.7]
+        out = brainmass.hyperbolic_tangent_coupling(x, conn, k=0.5, scale=2.0)
+        exp = 0.5 * np.tanh(2.0 * np.array([0.3, 0.7]))
+        assert u.math.allclose(out, jnp.asarray(exp), atol=1e-6)
+
+    def test_defaults(self):
+        # Documented defaults k=0.5, scale=2.0.
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[0.1, 0.2],
+                       [0.3, 0.4]])
+        out_default = brainmass.hyperbolic_tangent_coupling(x, conn)
+        out_explicit = brainmass.hyperbolic_tangent_coupling(x, conn, k=0.5, scale=2.0)
+        assert u.math.allclose(out_default, out_explicit)
+
+    def test_module_matches_kernel(self):
+        holder = _Holder()
+        holder.x = jnp.array([[0.5, -0.5],
+                              [1.0, 0.2]])
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        conn = jnp.array([[1.0, 0.5],
+                          [0.5, 1.0]])
+        coup = brainmass.HyperbolicTangentCoupling(x_ref, conn=conn, k=0.5, scale=2.0)
+        coup.init_state()
+        out = coup.update()
+        exp = brainmass.hyperbolic_tangent_coupling(holder.x, conn, k=0.5, scale=2.0)
+        assert out.shape == (2,)
+        assert u.math.allclose(out, exp)
+
+    def test_batched_and_flattened_conn(self):
+        batch = 3
+        conn2d = jnp.array([[1.0, 0.5],
+                            [0.5, 1.0]])
+        x_single = jnp.array([[0.2, 0.4],
+                              [0.6, 0.8]])
+        x = jnp.broadcast_to(x_single, (batch, 2, 2))
+        out = brainmass.hyperbolic_tangent_coupling(x, conn2d.reshape(-1), k=0.5)
+        exp_single = brainmass.hyperbolic_tangent_coupling(x_single, conn2d, k=0.5)
+        assert out.shape == (batch, 2)
+        assert u.math.allclose(out, jnp.broadcast_to(exp_single, (batch, 2)))
+
+
+class TestSigmoidalJansenRitCoupling:
+    """TVB SigmoidalJansenRit: pre-nonlinearity c = k*sum_j w_ij*sigma_JR(x_j)."""
+
+    @staticmethod
+    def _sigma_jr(x, cmin, cmax, midpoint, r):
+        return cmin + (cmax - cmin) / (1.0 + np.exp(r * (midpoint - x)))
+
+    def test_value_at_midpoint(self):
+        # At x = midpoint, sigma_JR = (cmin + cmax) / 2.
+        cmin, cmax, midpoint, r = 0.0, 0.005, 6.0, 0.56
+        conn = jnp.array([[0.2, 0.3],
+                          [0.5, 0.1]])
+        x = jnp.full((2, 2), midpoint)
+        out = brainmass.sigmoidal_jansen_rit_coupling(
+            x, conn, k=1.0, cmin=cmin, cmax=cmax, midpoint=midpoint, r=r)
+        exp = 1.0 * conn.sum(axis=1) * (cmin + cmax) / 2.0
+        assert u.math.allclose(out, exp, atol=1e-9)
+
+    def test_far_limits(self):
+        cmin, cmax, midpoint, r = 0.0, 0.005, 6.0, 0.56
+        conn = jnp.array([[1.0, 1.0],
+                          [1.0, 1.0]])
+        # Far above midpoint -> cmax; far below -> cmin.
+        x_hi = jnp.full((2, 2), 1e3)
+        x_lo = jnp.full((2, 2), -1e3)
+        out_hi = brainmass.sigmoidal_jansen_rit_coupling(
+            x_hi, conn, cmin=cmin, cmax=cmax, midpoint=midpoint, r=r)
+        out_lo = brainmass.sigmoidal_jansen_rit_coupling(
+            x_lo, conn, cmin=cmin, cmax=cmax, midpoint=midpoint, r=r)
+        assert u.math.allclose(out_hi, conn.sum(axis=1) * cmax, atol=1e-9)
+        assert u.math.allclose(out_lo, conn.sum(axis=1) * cmin, atol=1e-9)
+
+    def test_kernel_value(self):
+        cmin, cmax, midpoint, r = 0.0, 0.005, 6.0, 0.56
+        conn = jnp.array([[0.2, 0.3],
+                          [0.5, 0.1]])
+        x = jnp.array([[5.0, 6.0],
+                       [7.0, 4.0]])
+        out = brainmass.sigmoidal_jansen_rit_coupling(
+            x, conn, k=2.0, cmin=cmin, cmax=cmax, midpoint=midpoint, r=r)
+        s = self._sigma_jr(np.asarray(x), cmin, cmax, midpoint, r)
+        exp = 2.0 * np.sum(np.asarray(conn) * s, axis=1)
+        assert u.math.allclose(out, jnp.asarray(exp), atol=1e-9)
+
+    def test_module_matches_kernel(self):
+        holder = _Holder()
+        holder.x = jnp.array([[5.0, 6.0],
+                              [7.0, 4.0]])
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        conn = jnp.array([[0.2, 0.3],
+                          [0.5, 0.1]])
+        coup = brainmass.SigmoidalJansenRitCoupling(
+            x_ref, conn=conn, k=2.0, cmax=0.005, midpoint=6.0, r=0.56)
+        coup.init_state()
+        out = coup.update()
+        exp = brainmass.sigmoidal_jansen_rit_coupling(
+            holder.x, conn, k=2.0, cmax=0.005, midpoint=6.0, r=0.56)
+        assert out.shape == (2,)
+        assert u.math.allclose(out, exp)
+
+    def test_batched_and_flattened_conn(self):
+        batch = 3
+        conn2d = jnp.array([[0.2, 0.3],
+                            [0.5, 0.1]])
+        x_single = jnp.array([[5.0, 6.0],
+                              [7.0, 4.0]])
+        x = jnp.broadcast_to(x_single, (batch, 2, 2))
+        out = brainmass.sigmoidal_jansen_rit_coupling(x, conn2d.reshape(-1))
+        exp_single = brainmass.sigmoidal_jansen_rit_coupling(x_single, conn2d)
+        assert out.shape == (batch, 2)
+        assert u.math.allclose(out, jnp.broadcast_to(exp_single, (batch, 2)))
+
+
+class TestCouplingShapeValidation:
+    def test_sigmoidal_bad_x_shape_raises(self):
+        conn = jnp.ones((2, 3))
+        x = jnp.ones((2, 4))  # trailing neither (2,3) nor 6
+        with pytest.raises(ValueError):
+            brainmass.sigmoidal_coupling(x, conn)
+
+    def test_flattened_conn_non_square_raises(self):
+        conn = jnp.ones(6)  # not a perfect square
+        x = jnp.ones((2, 3))
+        with pytest.raises(ValueError):
+            brainmass.hyperbolic_tangent_coupling(x, conn)
+
+    def test_flattened_x_path(self):
+        # Flattened source (..., N_out*N_in) must reshape and match the 2-D form.
+        conn = jnp.array([[1.0, 0.5],
+                          [0.5, 1.0]])
+        x2d = jnp.array([[1.0, 2.0],
+                         [3.0, 4.0]])
+        x_flat = x2d.reshape(-1)
+        out_2d = brainmass.sigmoidal_coupling(x2d, conn, k=1.0)
+        out_flat = brainmass.sigmoidal_coupling(x_flat, conn, k=1.0)
+        assert u.math.allclose(out_2d, out_flat)
+
+    def test_kernel_3d_conn_raises(self):
+        x = jnp.ones((2, 2))
+        with pytest.raises(ValueError):
+            brainmass.sigmoidal_coupling(x, jnp.ones((2, 2, 2)))
+
+    def test_kernel_0d_x_raises(self):
+        with pytest.raises(ValueError):
+            brainmass.sigmoidal_coupling(jnp.asarray(1.0), jnp.ones((2, 2)))
+
+    def test_module_conn_ndim_raises(self):
+        holder = _Holder()
+        holder.x = jnp.ones((2, 2, 2))
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        with pytest.raises(ValueError):
+            brainmass.SigmoidalCoupling(x_ref, conn=jnp.ones((2, 2, 2)))
+        with pytest.raises(ValueError):
+            brainmass.HyperbolicTangentCoupling(x_ref, conn=jnp.ones((2, 2, 2)))
+        with pytest.raises(ValueError):
+            brainmass.SigmoidalJansenRitCoupling(x_ref, conn=jnp.ones((2, 2, 2)))
+
+
+class TestCouplingGradients:
+    """Gradients flow w.r.t. trainable scalars (FD-checked)."""
+
+    @staticmethod
+    def _fd(f, x, eps=1e-4):
+        return (f(x + eps) - f(x - eps)) / (2 * eps)
+
+    def test_grad_sigmoidal_k_slope_midpoint(self):
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[1.0, 0.5],
+                       [0.2, 0.8]])
+
+        def loss(p):
+            k, slope, midpoint = p
+            out = brainmass.sigmoidal_coupling(x, conn, k=k, slope=slope,
+                                               midpoint=midpoint)
+            return jnp.sum(out ** 2)
+
+        p0 = jnp.array([1.0, 1.5, 0.3])
+        g = jax.grad(loss)(p0)
+        assert np.all(np.isfinite(np.asarray(g)))
+        assert np.any(np.abs(np.asarray(g)) > 1e-6)
+        # FD check each component.
+        for i in range(3):
+            def fi(v, i=i):
+                return loss(p0.at[i].set(v))
+            fd = self._fd(fi, float(p0[i]))
+            assert np.allclose(np.asarray(g[i]), fd, rtol=2e-2, atol=1e-5)
+
+    def test_grad_tanh_k(self):
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[0.3, 0.1],
+                       [0.2, 0.4]])
+
+        def loss(k):
+            return jnp.sum(brainmass.hyperbolic_tangent_coupling(x, conn, k=k) ** 2)
+
+        g = jax.grad(loss)(0.5)
+        fd = self._fd(loss, 0.5)
+        assert np.isfinite(float(g)) and abs(float(g)) > 1e-6
+        assert np.allclose(float(g), fd, rtol=2e-2, atol=1e-5)
+
+    def test_grad_additive_bias(self):
+        conn = jnp.ones((2, 2))
+        x = jnp.array([[1.0, 2.0],
+                       [3.0, 4.0]])
+
+        def loss(b):
+            return jnp.sum(brainmass.additive_coupling(x, conn, k=1.0, b=b) ** 2)
+
+        g = jax.grad(loss)(0.5)
+        fd = self._fd(loss, 0.5)
+        assert np.isfinite(float(g)) and abs(float(g)) > 1e-6
+        assert np.allclose(float(g), fd, rtol=2e-2, atol=1e-5)
+
+
+class TestCouplingTrainableParam:
+    """Constrained-Param round-trip: explicit Param exposes a trainable ParamState."""
+
+    def test_trainable_k_roundtrip(self):
+        holder = _Holder()
+        holder.x = jnp.ones((2, 2))
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        k = brainstate.nn.Param(0.5, t=brainstate.nn.SigmoidT(0.0, 1.0))
+        coup = brainmass.SigmoidalCoupling(x_ref, conn=jnp.ones((2, 2)), k=k)
+        # Constrained value round-trips through the transform.
+        assert u.math.allclose(coup.k.value(), jnp.asarray(0.5), atol=1e-5)
+        # And it is exposed as a trainable ParamState.
+        ps = coup.states(brainstate.ParamState)
+        assert len(ps) >= 1
+
+    def test_default_scalars_not_trainable(self):
+        holder = _Holder()
+        holder.x = jnp.ones((2, 2))
+        x_ref = brainstate.nn.Prefetch(holder, 'x')
+        coup = brainmass.SigmoidalCoupling(x_ref, conn=jnp.ones((2, 2)))
+        # Defaults are Const -> no trainable ParamState.
+        ps = coup.states(brainstate.ParamState)
+        assert len(ps) == 0
+
+
+class TestCouplingNetworkIntegration:
+    """Wire a new coupling into a 2-node Network and run it under Simulator."""
+
+    def test_sigmoidal_network_with_delays(self):
+        brainstate.random.seed(0)
+        brainstate.environ.set(dt=0.1 * u.ms)  # prefetch_delay sizes from delay/dt
+        N = 2
+        conn = np.array([[0.0, 0.2],
+                         [0.3, 0.0]])
+        distance = np.array([[0.0, 1.0],
+                             [1.0, 0.0]])
+        node = brainmass.HopfStep(N, a=0.1)
+        net = brainmass.Network(
+            node, conn=conn, distance=distance, speed=1.0,
+            coupling='sigmoidal', coupled_var='x', k=0.5)
+        sim = brainmass.Simulator(net, dt=0.1 * u.ms)
+        res = sim.run(5.0 * u.ms, monitors=lambda m: m.node.x.value)
+        out = np.asarray(u.get_magnitude(res['output']))
+        assert out.shape == (50, N)
+        assert np.all(np.isfinite(out))
+
+    def test_tanh_network_instantaneous(self):
+        brainstate.random.seed(0)
+        brainstate.environ.set(dt=0.1 * u.ms)  # prefetch_delay sizes from delay/dt
+        N = 2
+        conn = np.array([[0.0, 0.2],
+                         [0.3, 0.0]])
+        node = brainmass.HopfStep(N, a=0.1)
+        net = brainmass.Network(
+            node, conn=conn, coupling='tanh', coupled_var='x', k=0.5)
+        sim = brainmass.Simulator(net, dt=0.1 * u.ms)
+        res = sim.run(3.0 * u.ms, monitors=lambda m: m.node.x.value)
+        out = np.asarray(u.get_magnitude(res['output']))
+        assert out.shape == (30, N)
+        assert np.all(np.isfinite(out))
+
+    def test_sigmoidal_jansen_rit_network(self):
+        brainstate.random.seed(0)
+        brainstate.environ.set(dt=0.1 * u.ms)  # prefetch_delay sizes from delay/dt
+        N = 2
+        conn = np.array([[0.0, 0.2],
+                         [0.3, 0.0]])
+        node = brainmass.HopfStep(N, a=0.1)
+        net = brainmass.Network(
+            node, conn=conn, coupling='sigmoidal_jansen_rit', coupled_var='x', k=1.0)
+        sim = brainmass.Simulator(net, dt=0.1 * u.ms)
+        res = sim.run(3.0 * u.ms, monitors=lambda m: m.node.x.value)
+        out = np.asarray(u.get_magnitude(res['output']))
+        assert out.shape == (30, N)
+        assert np.all(np.isfinite(out))
+
+    def test_bad_coupling_name_raises(self):
+        brainstate.environ.set(dt=0.1 * u.ms)
+        node = brainmass.HopfStep(2, a=0.1)
+        with pytest.raises(ValueError):
+            brainmass.Network(node, conn=np.zeros((2, 2)),
+                              coupling='nope', coupled_var='x')

--- a/brainmass/network.py
+++ b/brainmass/network.py
@@ -29,7 +29,14 @@ import brainunit as u
 import numpy as np
 from brainstate.nn import Param
 
-from .coupling import DiffusiveCoupling, AdditiveCoupling, LaplacianConnParam
+from .coupling import (
+    DiffusiveCoupling,
+    AdditiveCoupling,
+    SigmoidalCoupling,
+    HyperbolicTangentCoupling,
+    SigmoidalJansenRitCoupling,
+    LaplacianConnParam,
+)
 from .utils import delay_index
 
 __all__ = [
@@ -65,12 +72,18 @@ class Network(brainstate.nn.Module):
         Conduction speed. If ``distance`` carries length units and ``speed`` carries
         ``length / time`` units the delay is unit-correct; if both are plain numbers
         the quotient is interpreted as milliseconds (matching the examples).
-    coupling : {'diffusive', 'additive', 'laplacian'}, default 'diffusive'
+    coupling : {'diffusive', 'additive', 'laplacian', 'sigmoidal', 'tanh', \
+'sigmoidal_jansen_rit'}, default 'diffusive'
         Coupling kernel. ``'diffusive'`` uses
         :class:`~brainmass.DiffusiveCoupling` (``k * sum_j conn_ij (x_j - x_i)``);
         ``'additive'`` uses :class:`~brainmass.AdditiveCoupling`
         (``k * sum_j conn_ij x_j``); ``'laplacian'`` wraps ``conn`` in a
-        :class:`~brainmass.LaplacianConnParam` and applies it additively.
+        :class:`~brainmass.LaplacianConnParam` and applies it additively. The
+        nonlinear forms ``'sigmoidal'`` (:class:`~brainmass.SigmoidalCoupling`),
+        ``'tanh'`` (:class:`~brainmass.HyperbolicTangentCoupling`) and
+        ``'sigmoidal_jansen_rit'`` (:class:`~brainmass.SigmoidalJansenRitCoupling`)
+        apply their nonlinearity to the same delayed source read, with ``k`` as the
+        global strength (TVB ``G``; ``G ≡ k``).
     coupled_var : str
         Name of the node state variable to couple (e.g. ``'rE'``, ``'x'``, ``'V'``).
         Validated at initialisation; an unknown name raises ``ValueError``.
@@ -156,10 +169,16 @@ class Network(brainstate.nn.Module):
                 else LaplacianConnParam(conn_for_coupling)
             )
             self.coupling = AdditiveCoupling(src, lap, k=k)
+        elif coupling == 'sigmoidal':
+            self.coupling = SigmoidalCoupling(src, conn_for_coupling, k=k)
+        elif coupling == 'tanh':
+            self.coupling = HyperbolicTangentCoupling(src, conn_for_coupling, k=k)
+        elif coupling == 'sigmoidal_jansen_rit':
+            self.coupling = SigmoidalJansenRitCoupling(src, conn_for_coupling, k=k)
         else:
             raise ValueError(
-                f"coupling must be 'diffusive', 'additive' or 'laplacian'; "
-                f"got {coupling!r}."
+                f"coupling must be 'diffusive', 'additive', 'laplacian', 'sigmoidal', "
+                f"'tanh' or 'sigmoidal_jansen_rit'; got {coupling!r}."
             )
 
     # ------------------------------------------------------------------ helpers

--- a/docs/apis/coupling.rst
+++ b/docs/apis/coupling.rst
@@ -11,10 +11,21 @@ Overview
 --------
 
 Coupling maps activity from source nodes to target nodes via a structural connectivity matrix.
-Two fundamental coupling forms are provided:
+``brainmass`` provides both **linear** and **nonlinear** coupling forms, matching the canonical
+TVB coupling library:
 
-1. **Diffusive Coupling**: Proportional to the difference between connected nodes
-2. **Additive Coupling**: Directly sums weighted inputs from connected nodes
+1. **Diffusive Coupling**: Proportional to the difference between connected nodes (TVB *Difference*)
+2. **Additive / Linear Coupling**: Weighted sum of neighbour inputs, with optional bias (TVB *Linear*)
+3. **Sigmoidal Coupling**: Logistic nonlinearity applied *after* the network sum (TVB *Sigmoidal*)
+4. **Hyperbolic-Tangent Coupling**: Symmetric ``tanh`` saturation *after* the sum (TVB *HyperbolicTangent*)
+5. **Sigmoidal Jansen-Rit Coupling**: Jansen-Rit firing-rate sigmoid applied *before* the sum
+   (TVB *SigmoidalJansenRit*)
+
+.. note::
+
+   ``brainmass`` names the global coupling strength ``k``; TVB / tvboptim call it ``G``. The two
+   are identical: **G ≡ k**. New trainable scalars (``slope``, ``midpoint``, ``cmin``/``cmax``,
+   ``r``, ``b``) go through ``Param.init`` and are constrainable / fittable like ``k``.
 
 
 Coupling Types
@@ -30,9 +41,18 @@ Coupling Types
    * - Diffusive
      - :math:`k \sum_j W_{ij} (x_j - x_i)`
      - Drives nodes toward neighbors' states
-   * - Additive
-     - :math:`k \sum_j W_{ij} x_j`
-     - Weighted sum of neighbor inputs
+   * - Additive / Linear
+     - :math:`k \sum_j W_{ij} x_j + b`
+     - Weighted sum of neighbor inputs (+ bias)
+   * - Sigmoidal
+     - :math:`k\,\sigma\!\big(s\,(a\sum_j W_{ij} x_j + b - m)\big)`
+     - Logistic saturation after the sum
+   * - Hyperbolic Tangent
+     - :math:`k\,\tanh\!\big(s\sum_j W_{ij} x_j\big)`
+     - Symmetric saturation after the sum
+   * - Sigmoidal Jansen-Rit
+     - :math:`k \sum_j W_{ij}\,\sigma_{\mathrm{JR}}(x_j)`
+     - Firing-rate sigmoid before the sum
 
 
 Mathematical Details
@@ -55,13 +75,45 @@ This can be rewritten using the graph Laplacian :math:`\mathbf{L}`:
 
 where :math:`L_{ij} = \delta_{ij} \sum_k W_{ik} - W_{ij}`.
 
-**Additive Coupling**
+**Additive / Linear Coupling**
 
 The additive coupling input is:
 
 .. math::
 
-   C_i = k \sum_{j=1}^{N} W_{ij} x_j = k (\mathbf{W}^T \mathbf{x})_i
+   C_i = k \sum_{j=1}^{N} W_{ij} x_j + b = k (\mathbf{W}^T \mathbf{x})_i + b
+
+where :math:`b` is an optional offset (default :math:`0`, which reproduces the bias-free
+coupling exactly). This is TVB's *Linear* coupling.
+
+**Nonlinear Couplings**
+
+Three nonlinear forms close parity with the TVB coupling library. The *post-nonlinearity*
+forms apply a saturating function to the network sum:
+
+.. math::
+
+   \text{Sigmoidal:}\quad
+   C_i &= k\,\sigma\!\Big(s\,\big(a\textstyle\sum_j W_{ij} x_j + b - m\big)\Big),
+   \qquad \sigma(z) = \frac{1}{1 + e^{-z}} \\[4pt]
+   \text{Hyperbolic Tangent:}\quad
+   C_i &= k\,\tanh\!\Big(s\textstyle\sum_j W_{ij} x_j\Big)
+
+with slope :math:`s`, midpoint :math:`m`, input scaling :math:`a` and offset :math:`b`. The
+*pre-nonlinearity* Jansen-Rit form applies a firing-rate sigmoid to each source **before**
+summation:
+
+.. math::
+
+   C_i = k \sum_j W_{ij}\,\sigma_{\mathrm{JR}}(x_j),
+   \qquad
+   \sigma_{\mathrm{JR}}(x) = c_{\min} + \frac{c_{\max} - c_{\min}}{1 + e^{\,r\,(m - x)}}
+
+where :math:`x_j` is the presynaptic source (e.g. the Jansen-Rit :math:`y_1 - y_2`),
+:math:`r` the steepness and :math:`m` the half-activation potential. Because the
+transcendental functions require dimensionless arguments, their input is reduced to its
+magnitude; the post-nonlinearity output then carries the units of :math:`k`, and the
+Jansen-Rit output the units of :math:`k\,W`.
 
 
 Connectivity Matrix Conventions
@@ -92,6 +144,9 @@ Class-Based Coupling
 
    DiffusiveCoupling
    AdditiveCoupling
+   SigmoidalCoupling
+   HyperbolicTangentCoupling
+   SigmoidalJansenRitCoupling
 
 
 **Example: Diffusive Coupling**
@@ -140,6 +195,9 @@ Functional Coupling
 
    diffusive_coupling
    additive_coupling
+   sigmoidal_coupling
+   hyperbolic_tangent_coupling
+   sigmoidal_jansen_rit_coupling
 
 
 Functional APIs provide stateless coupling for imperative use:
@@ -364,6 +422,17 @@ Common Issues
 **Self-Connections:**
 - Diagonal elements ``W[i, i]`` represent self-connections
 - Often set to zero to avoid redundant self-coupling
+
+
+References
+----------
+
+- Jansen, B. H., & Rit, V. G. (1995). Electroencephalogram and visual evoked potential
+  generation in a mathematical model of coupled cortical columns. *Biological Cybernetics*,
+  73(4), 357-366. (Sigmoidal Jansen-Rit coupling.)
+- Sanz-Leon, P., Knock, S. A., Spiegler, A., & Jirsa, V. K. (2015). Mathematical framework
+  for large-scale brain network modeling in The Virtual Brain. *NeuroImage*, 111, 385-430.
+  (TVB *Sigmoidal* / *HyperbolicTangent* / *Linear* / *Difference* couplings.)
 
 
 See Also


### PR DESCRIPTION
## Summary

Closes coupling parity with tvboptim (sub-project F, coupling slice). Adds the **nonlinear couplings** brainmass lacked, as `function + Module` pairs in `coupling.py`, mirroring the existing kernel+thin-Module pattern (no new base class):

- **`sigmoidal_coupling` / `SigmoidalCoupling`** — TVB *Sigmoidal*, post-nonlinearity: `c = k·σ(slope·(a·Σ_j w_ij x_j + b − midpoint))`
- **`hyperbolic_tangent_coupling` / `HyperbolicTangentCoupling`** — TVB *HyperbolicTangent*, post: `c = k·tanh(scale·Σ_j w_ij x_j)`
- **`sigmoidal_jansen_rit_coupling` / `SigmoidalJansenRitCoupling`** — TVB *SigmoidalJansenRit*, pre-nonlinearity: `c = k·Σ_j w_ij·σ_JR(x_j)`
- **Linear bias** `b` on `additive_coupling` / `AdditiveCoupling` (default `0.0`, back-compat bit-for-bit)

### Conventions
- brainmass keeps `k` for the global strength; **`G ≡ k`** documented in every docstring + the docs page.
- New scalars (`slope`, `midpoint`, `cmin`/`cmax`, `r`, `a`, `b`) go through `Param.init` — float defaults yield non-trainable `Const`, so **no spurious trainable params** (Fitter unaffected).
- Delays stay upstream via `prefetch_delay` — each kernel works with an instantaneous `prefetch` or a `prefetch_delay` callable; **no new `Delayed*` twins**.
- Post-nonlinearity output carries `k`'s unit; the JR pre-form carries `k·conn`'s unit (σ dimensionless).

### Integration
`Network` gains `'sigmoidal'` / `'tanh'` / `'sigmoidal_jansen_rit'` dispatch.

## Validation
Closed-form oracles (sigmoid@0 = `k·σ(−slope·midpoint)`; tanh→`±k`; σ_JR@midpoint = `k·Σw·(cmin+cmax)/2`), gradient (FD) wrt `k`/`slope`/`midpoint`/`b`, shape/unit/dtype, batched leading dims, 1-D flattened vs 2-D `conn` (+ flattened `x`), delayed-source via a 2-node `Network` under `Simulator`, constrained-`Param` round-trip, and `b=0` ≡ old `AdditiveCoupling` (`np.array_equal`).

- Full suite **green**; `coupling.py` **95.93%** / `network.py` **100%** coverage on changed code (new helper + 3 kernels + 3 Modules + bias = 100%; residual misses are pre-existing).
- Docs: `docs/apis/coupling.rst` updated with equations + references (Jansen & Rit 1995; Sanz-Leon/TVB 2015) + runnable doctest Examples in the docstrings.

Deferred: `KuramotoCoupling`, hierarchical `SubspaceCoupling`, observation models (goal-12).