### PR TITLE
feat: convolution BOLD + HRF kernels + TemporalAverage + FCD-distribution objectives (goal-12)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -568,3 +568,64 @@ orchestration (Simulator / Network / Fitter) on top of these primitives.
   Epileptor, Larter-Breakspear, Coombes-Byrne (complex, goal-09) · Generic2dOscillator,
   WongWang-ExcInh, Lorenz, Linear (canonical/E-I, goal-10). brainmass additionally has HORN + forward
   models (BOLD/EEG/MEG lead fields) with no tvboptim equivalent.
+
+### 2026-06-19 · goal-12 observation-parity
+
+- **Closed the observation gap vs tvboptim** (sub-project F, observation slice). New module
+  `brainmass/observation.py` (+ `observation_test.py`, **100 %** cov): `HRFKernel` base + 4 closed-form
+  HRF kernels (`FirstOrderVolterraHRFKernel`, `GammaHRFKernel`, `DoubleExponentialHRFKernel`,
+  `MixtureOfGammasHRFKernel`), the convolution `HRFBold` observation, and the standalone
+  `TemporalAverage` monitor. Extended `objectives.py` (**100 %** cov) with the FCD-*distribution*
+  objectives. All exported top-level (`# Observation models` block in `__init__`); existing
+  `BOLDSignal` (Balloon ODE) and EEG/MEG lead fields **untouched**. Suite **586 → 607 passed**
+  (50 observation + 14 objectives + 2 import_compat; no regressions).
+- **Convolution-vs-Balloon BOLD guidance (documented in both classes + a forward.rst table):**
+  `HRFBold` = a single linear convolution `BOLD = k1·V0·(h * y_ds − 1)` (downsample→convolve→decimate)
+  — fast, simple, **differentiable in its scalar params** → the choice for *fitting*. `BOLDSignal` =
+  the 4-state Balloon-Windkessel ODE → the choice when biophysical realism matters. Empirically they
+  **track each other**: best-lag correlation **0.98** on a slow drive (zero-lag only 0.73 — the two
+  hemodynamics have different intrinsic latencies, so compare BOLD waveforms over a ±few-TR lag, the
+  standard way; a naive zero-lag corr under-measures agreement).
+- **Delegation audit (what braintools already had vs what we added):**
+  - **Reused** `braintools.metric.functional_connectivity_dynamics` (FCD matrix) — same call as goal-08's `fcd`.
+  - **Delegated to jax:** KDE → `jax.scipy.stats.gaussian_kde`; FFT conv → `jax.scipy.signal.fftconvolve`;
+    direct conv → `jnp.convolve`. **braintools.metric has no KDE/KS/Wasserstein/conv.**
+  - **Hand-implemented (the genuine gap, tiny cumsum-based):** `ks_distance(p,q)` = `max|cdf_p−cdf_q|`,
+    `wasserstein_1d(p,q,x)` = `Σ|cdf_p−cdf_q|·dx`. Both normalise cumsums internally so they accept
+    densities *or* histograms.
+- **`TemporalAverage` ↔ `Simulator`:** kept it a **standalone thin observation** (`TemporalAverage(period)
+  (signal, dt)`), NOT a `Simulator` change. It is the *averaging* (anti-aliased) complement to the
+  point-decimation `Simulator(sample_every=k)` — apply it as a post-transform on a run trajectory; it
+  is also the downsampler `HRFBold` uses internally. `y[k]=mean(signal[k·w:(k+1)·w])`, `w=round(period/dt)`,
+  `n_win=T//w`, trailing partial window dropped; `round(period/dt)<1` raises. Preserves units.
+- **FCD-distribution objective API** (the standard FCD fitting target = the *distribution* of FCD
+  off-diagonal values, not the matrix correlation `fcd` already had): primitives `fcd_distribution`
+  (KDE of the upper-triangle on a `[-0.99,0.99]` grid, normalised to ∫=1), `ks_distance`, `wasserstein_1d`;
+  builders `fcd_wasserstein(window_size,step_size,midpoints,bw_method,n_diag)` and `fcd_ks(...)` →
+  `loss(prediction,target)` (0 on identity). **KS vs Wasserstein differentiability:** KS is a `max`
+  (non-smooth — its grad is the indicator at the argmax) → use `fcd_ks` for *evaluation/reporting*;
+  `wasserstein_1d` is smooth/grad-friendly → `fcd_wasserstein` is the recommended *fitting* loss
+  (grad verified finite). Degenerate (constant, zero-variance) input → singular KDE → **`nan`** distance
+  (documented + tested).
+- **Validation = embedded-reference-oracle, NOT `requires_tvboptim` gating.** The goal-12 prompt asked
+  for a `requires_tvboptim` marker, but goal-10's standing user override deleted all tvboptim test-gating
+  machinery (this branch merges to main). Reconciled by following the goal-09/10 pattern: kernels checked
+  against **verbatim embedded transcriptions** of tvboptim's closed forms (always-on, no live import) +
+  analytic props (`h(0)=0`, peak=`a`, real underdamped `ω`); `HRFBold` against an **independent numpy +
+  `scipy.signal.fftconvolve`** reproduction (genuinely different libs, not a copy of the impl). scipy
+  cross-checks are always-on (scipy is a hard braintools dep, added to requirements-dev explicitly):
+  `ks_distance` is **exact** vs `scipy.stats.ks_2samp` (build per-value histograms on the pooled-sorted
+  unique grid so the normalised cumsums ARE the empirical CDFs scipy maximises); `wasserstein_1d` ≈
+  `scipy.stats.wasserstein_distance` on a fine grid (rtol 2e-2, it's a Riemann sum of ∫|ΔCDF|dx).
+- **Gotchas:** (a) `BOLDSignal` is dimensionless and needs a **unitless** `dt` in `environ` (its RK2 does
+  `t+dt`; a `Quantity` dt → `ms + 1` UnitMismatch) — drive it with `dt=0.01` while `HRFBold` gets the
+  matching real-time `10*u.ms`. (b) HRF kernels take `t` as a time `Quantity` (→ seconds) or a plain array
+  (assumed **ms**, the TVB convention); they return a **dimensionless** array; grad flows w.r.t. continuous
+  params (`tau_s`/`tau`/`λ`) when the kernel is built *inside* the differentiated fn (`n`/`duration` are
+  int-cast → non-diff, fine). (c) docstring Examples use `.. code-block:: python` + `>>>` (CLAUDE.md +
+  goal-09/10 model convention, validated by `DocTestFinder`); RST doc Examples use bare `>>>` (sphinx
+  `-b doctest` gate, 159 tests / 0 fail). No sphinx-doctest in CI (deploy-docs runs `-b html` only).
+- **brainmass now meets/exceeds tvboptim's observation set:** convolution BOLD + HRF-kernel family +
+  `TemporalAverage` + FCD-distribution objectives (this goal) · Balloon-Windkessel ODE BOLD + FC/FCD-matrix
+  objectives + `Simulator(sample_every=)` subsampling (pre-existing). **EEG/MEG lead-field forwards remain a
+  brainmass-only advantage** (tvboptim has none); sEEG/iEEG noted as future (tvboptim lacks them too).

--- a/brainmass/__init__.py
+++ b/brainmass/__init__.py
@@ -58,6 +58,16 @@ from .larter_breakspear import LarterBreakspearStep
 from .lorenz import LorenzStep
 from .leadfield import LeadfieldReadout
 from .linear import ThresholdLinearStep, LinearStep
+# Convolution-based observation models (HRF BOLD, temporal averaging)
+from .observation import (
+    HRFKernel,
+    FirstOrderVolterraHRFKernel,
+    GammaHRFKernel,
+    DoubleExponentialHRFKernel,
+    MixtureOfGammasHRFKernel,
+    TemporalAverage,
+    HRFBold,
+)
 # Noise processes
 from .noise import (
     Noise,
@@ -174,6 +184,15 @@ __all__ = [
     'LeadFieldModel',
     'EEGLeadFieldModel',
     'MEGLeadFieldModel',
+
+    # Observation models (convolution BOLD, HRF kernels, temporal averaging)
+    'HRFKernel',
+    'FirstOrderVolterraHRFKernel',
+    'GammaHRFKernel',
+    'DoubleExponentialHRFKernel',
+    'MixtureOfGammasHRFKernel',
+    'TemporalAverage',
+    'HRFBold',
 
     # Coupling mechanisms
     'DiffusiveCoupling',

--- a/brainmass/import_compat_test.py
+++ b/brainmass/import_compat_test.py
@@ -146,3 +146,27 @@ def test_unknown_attribute_raises():
     """An attribute that is neither current nor a legacy alias raises."""
     with pytest.raises(AttributeError):
         _ = brainmass.DefinitelyNotAModelName
+
+
+# --- goal-12 observation layer: new module + objectives functions resolve ---
+
+_OBSERVATION_SYMBOLS = [
+    'HRFKernel', 'FirstOrderVolterraHRFKernel', 'GammaHRFKernel',
+    'DoubleExponentialHRFKernel', 'MixtureOfGammasHRFKernel',
+    'TemporalAverage', 'HRFBold',
+]
+
+
+def test_observation_module_path_resolves():
+    """``brainmass.observation.<name>`` resolves to the same top-level object."""
+    mod = importlib.import_module('brainmass.observation')
+    for s in _OBSERVATION_SYMBOLS:
+        assert getattr(mod, s, None) is not None, f"brainmass.observation missing {s}"
+        assert getattr(brainmass, s) is getattr(mod, s), f"{s} diverged from brainmass.{s}"
+
+
+def test_objectives_fcd_distribution_functions_resolve():
+    """The goal-12 FCD-distribution objectives are exposed on ``brainmass.objectives``."""
+    for s in ['fcd_distribution', 'ks_distance', 'wasserstein_1d', 'fcd_ks', 'fcd_wasserstein']:
+        assert getattr(brainmass.objectives, s, None) is not None, s
+        assert s in brainmass.objectives.__all__, f"{s} not in objectives.__all__"

--- a/brainmass/objectives.py
+++ b/brainmass/objectives.py
@@ -29,6 +29,7 @@ unit-checked (subtracting incompatible units raises).
 
 import braintools
 import brainunit as u
+import jax
 import jax.numpy as jnp
 
 __all__ = [
@@ -37,8 +38,17 @@ __all__ = [
     'fc_rmse',
     'cosine_sim',
     'fcd',
+    'fcd_distribution',
+    'ks_distance',
+    'wasserstein_1d',
+    'fcd_ks',
+    'fcd_wasserstein',
     'combine',
 ]
+
+#: Default evaluation grid for FCD off-diagonal distributions (correlations live
+#: in [-1, 1]); 100 points on [-0.99, 0.99] matching the tvboptim convention.
+_DEFAULT_FCD_MIDPOINTS = jnp.linspace(-0.99, 0.99, 100)
 
 
 def _mag(x):
@@ -207,6 +217,240 @@ def fcd(window_size=30, step_size=5, as_loss=False):
         return 1.0 - corr if as_loss else corr
 
     return fn
+
+
+def fcd_distribution(fcd_matrix, midpoints=None, n_diag=1, bw_method=None, normalize=True):
+    r"""Kernel-density estimate of the FCD off-diagonal value distribution.
+
+    The standard FCD fitting target is the *distribution* of the upper-triangle
+    (off-diagonal) values of the FCD matrix -- not the matrix itself. This
+    surfaces that distribution as a smooth density on a fixed grid via
+    :func:`jax.scipy.stats.gaussian_kde` (delegated; ``braintools`` provides no
+    KDE).
+
+    Parameters
+    ----------
+    fcd_matrix : array
+        Square FCD matrix (e.g. from :func:`fcd` or
+        :func:`braintools.metric.functional_connectivity_dynamics`).
+    midpoints : array, optional
+        Evaluation grid. Default: 100 points on ``[-0.99, 0.99]`` (FCD values are
+        correlations).
+    n_diag : int, default 1
+        Diagonal offset for the upper-triangle extraction (``1`` excludes the
+        main diagonal).
+    bw_method : optional
+        Bandwidth selector forwarded to :func:`jax.scipy.stats.gaussian_kde`
+        (default ``None`` = Scott's rule). Smaller values give sharper densities.
+    normalize : bool, default True
+        Renormalise the evaluated density to integrate to 1 over ``midpoints``
+        (KDE on a finite grid never integrates to exactly 1).
+
+    Returns
+    -------
+    jax.Array
+        Density evaluated on ``midpoints``.
+
+    See Also
+    --------
+    fcd_ks, fcd_wasserstein : objective builders comparing two FCD distributions.
+    """
+    if midpoints is None:
+        midpoints = _DEFAULT_FCD_MIDPOINTS
+    vals = fcd_matrix[jnp.triu_indices(fcd_matrix.shape[0], k=n_diag)]
+    kde = jax.scipy.stats.gaussian_kde(vals, bw_method=bw_method)
+    density = kde.evaluate(midpoints)
+    if normalize:
+        dx = midpoints[1] - midpoints[0]
+        density = density / (jnp.sum(density) * dx)
+    return density
+
+
+def ks_distance(p, q):
+    r"""Kolmogorov-Smirnov statistic between two 1-D densities / histograms.
+
+    Each cumulative sum is normalised to a proper CDF before the supremum is
+    taken, so the result lies in ``[0, 1]`` independent of bin width and is
+    directly comparable to :func:`scipy.stats.ks_2samp`.
+
+    .. math::
+
+        D = \sup_x \left| F_p(x) - F_q(x) \right|.
+
+    Parameters
+    ----------
+    p, q : array
+        Densities or (unnormalised) histograms on a shared, ordered grid.
+
+    Returns
+    -------
+    jax.Array
+        Scalar KS statistic in ``[0, 1]``.
+
+    Notes
+    -----
+    The supremum (``max``) makes this **non-smooth**: its gradient is the
+    indicator at the argmax, so prefer :func:`wasserstein_1d` (and
+    :func:`fcd_wasserstein`) when the distance is a *fitting* loss. Use KS for
+    evaluation / reporting, where literature comparability matters.
+
+    See Also
+    --------
+    wasserstein_1d : smooth, gradient-friendly distributional distance.
+    """
+    p_cdf = jnp.cumsum(p)
+    q_cdf = jnp.cumsum(q)
+    p_cdf = p_cdf / p_cdf[-1]
+    q_cdf = q_cdf / q_cdf[-1]
+    return jnp.max(jnp.abs(p_cdf - q_cdf))
+
+
+def wasserstein_1d(p, q, x):
+    r"""Wasserstein-1 distance between two 1-D densities on a shared grid.
+
+    .. math::
+
+        W_1(p, q) = \int \left| F_p(x) - F_q(x) \right| \, dx,
+
+    discretised on the uniform grid ``x``. Both inputs are normalised internally
+    (CDFs run 0..1), so ``p`` and ``q`` may be densities or unnormalised
+    histograms; the returned value lives in the same units as ``x``. Unlike
+    :func:`ks_distance` this is **smooth and differentiable** in both inputs,
+    making it the preferred distributional loss for gradient-based fitting.
+    Matches :func:`scipy.stats.wasserstein_distance` as the grid is refined.
+
+    Parameters
+    ----------
+    p, q : array
+        Densities or histograms on the shared grid ``x``.
+    x : array
+        Uniform evaluation grid (same length as ``p`` / ``q``).
+
+    Returns
+    -------
+    jax.Array
+        Scalar Wasserstein-1 distance.
+
+    See Also
+    --------
+    ks_distance : the non-smooth KS counterpart.
+    """
+    dx = x[1] - x[0]
+    p_cdf = jnp.cumsum(p)
+    q_cdf = jnp.cumsum(q)
+    p_cdf = p_cdf / p_cdf[-1]
+    q_cdf = q_cdf / q_cdf[-1]
+    return jnp.sum(jnp.abs(p_cdf - q_cdf)) * dx
+
+
+def _fcd_distribution_pair(prediction, target, window_size, step_size,
+                           midpoints, bw_method, n_diag):
+    """Compute the FCD off-diagonal density of prediction and target."""
+    fcd_p = braintools.metric.functional_connectivity_dynamics(
+        _mag(prediction), window_size=window_size, step_size=step_size
+    )
+    fcd_t = braintools.metric.functional_connectivity_dynamics(
+        _mag(target), window_size=window_size, step_size=step_size
+    )
+    dp = fcd_distribution(fcd_p, midpoints=midpoints, n_diag=n_diag, bw_method=bw_method)
+    dq = fcd_distribution(fcd_t, midpoints=midpoints, n_diag=n_diag, bw_method=bw_method)
+    return dp, dq
+
+
+def fcd_wasserstein(window_size=30, step_size=5, midpoints=None, bw_method=None, n_diag=1):
+    r"""Build a Wasserstein FCD-distribution loss (smooth, grad-friendly).
+
+    Compares the *distribution* of FCD off-diagonal values of the prediction and
+    target -- the standard FCD fitting target -- rather than the FCD matrix
+    correlation (:func:`fcd`). The :func:`wasserstein_1d` distance is smooth, so
+    this is the recommended FCD objective for gradient-based fitting.
+
+    Parameters
+    ----------
+    window_size, step_size : int
+        Sliding-window length and stride (in samples) for
+        :func:`braintools.metric.functional_connectivity_dynamics`.
+    midpoints : array, optional
+        FCD-value evaluation grid (default 100 points on ``[-0.99, 0.99]``).
+    bw_method : optional
+        KDE bandwidth forwarded to :func:`fcd_distribution`.
+    n_diag : int, default 1
+        Upper-triangle diagonal offset.
+
+    Returns
+    -------
+    callable
+        ``loss(prediction, target) -> scalar`` Wasserstein-1 distance between the
+        two FCD distributions (a quantity to *minimise*; ``0`` on identity).
+
+    See Also
+    --------
+    fcd_ks : the non-smooth KS counterpart.
+    fcd : FCD *matrix* correlation objective.
+
+    Examples
+    --------
+    >>> import numpy as np, jax.numpy as jnp
+    >>> from brainmass import objectives
+    >>> rng = np.random.default_rng(0)
+    >>> x = jnp.asarray(rng.standard_normal((200, 6)))
+    >>> loss = objectives.fcd_wasserstein(window_size=30, step_size=5)
+    >>> float(loss(x, x))
+    0.0
+    """
+    if midpoints is None:
+        midpoints = _DEFAULT_FCD_MIDPOINTS
+
+    def loss(prediction, target):
+        dp, dq = _fcd_distribution_pair(
+            prediction, target, window_size, step_size, midpoints, bw_method, n_diag
+        )
+        return wasserstein_1d(dp, dq, midpoints)
+
+    return loss
+
+
+def fcd_ks(window_size=30, step_size=5, midpoints=None, bw_method=None, n_diag=1):
+    r"""Build a Kolmogorov-Smirnov FCD-distribution loss.
+
+    Like :func:`fcd_wasserstein` but using the :func:`ks_distance` statistic
+    between the two FCD off-diagonal distributions. The KS statistic is the
+    common literature metric for FCD comparison, but it is **non-smooth** (a
+    supremum); prefer :func:`fcd_wasserstein` when the loss drives a gradient
+    optimiser, and use this for evaluation / reporting.
+
+    Parameters
+    ----------
+    window_size, step_size : int
+        Sliding-window length and stride (in samples) for
+        :func:`braintools.metric.functional_connectivity_dynamics`.
+    midpoints : array, optional
+        FCD-value evaluation grid (default 100 points on ``[-0.99, 0.99]``).
+    bw_method : optional
+        KDE bandwidth forwarded to :func:`fcd_distribution`.
+    n_diag : int, default 1
+        Upper-triangle diagonal offset.
+
+    Returns
+    -------
+    callable
+        ``loss(prediction, target) -> scalar`` KS distance between the two FCD
+        distributions (a quantity to *minimise*; ``0`` on identity).
+
+    See Also
+    --------
+    fcd_wasserstein : the smooth, gradient-friendly counterpart.
+    """
+    if midpoints is None:
+        midpoints = _DEFAULT_FCD_MIDPOINTS
+
+    def loss(prediction, target):
+        dp, dq = _fcd_distribution_pair(
+            prediction, target, window_size, step_size, midpoints, bw_method, n_diag
+        )
+        return ks_distance(dp, dq)
+
+    return loss
 
 
 def combine(*weighted_objectives):

--- a/brainmass/objectives_test.py
+++ b/brainmass/objectives_test.py
@@ -199,3 +199,165 @@ def test_objectives_are_grad_safe(builder, signals):
 
     g = jax.grad(loss)(1.0)
     assert np.isfinite(float(g))
+
+
+# --------------------------------------------------------------------------- #
+# FCD-distribution primitives: ks_distance / wasserstein_1d / fcd_distribution #
+# --------------------------------------------------------------------------- #
+
+from scipy.stats import ks_2samp, wasserstein_distance  # noqa: E402
+
+
+def test_ks_distance_matches_scipy_exactly():
+    rng = np.random.default_rng(1)
+    a = rng.standard_normal(300)
+    b = rng.standard_normal(250) + 0.4
+    # Build per-value "histograms" on the pooled sorted unique grid so that the
+    # normalised cumulative sums ARE the empirical CDFs evaluated at the data
+    # points -- the exact quantity scipy's ks_2samp maximises.
+    grid = np.unique(np.concatenate([a, b]))
+    pa = np.array([np.sum(a == g) for g in grid], dtype=float)
+    pb = np.array([np.sum(b == g) for g in grid], dtype=float)
+    got = float(objectives.ks_distance(jnp.asarray(pa), jnp.asarray(pb)))
+    expected = float(ks_2samp(a, b).statistic)
+    assert np.isclose(got, expected, atol=1e-6)
+
+
+def test_ks_distance_in_unit_interval():
+    rng = np.random.default_rng(2)
+    p = jnp.asarray(np.abs(rng.standard_normal(50)))
+    q = jnp.asarray(np.abs(rng.standard_normal(50)))
+    d = float(objectives.ks_distance(p, q))
+    assert 0.0 <= d <= 1.0
+
+
+def test_wasserstein_1d_matches_scipy_on_fine_grid():
+    rng = np.random.default_rng(3)
+    a = rng.normal(0.0, 1.0, 4000)
+    b = rng.normal(0.6, 1.3, 4000)
+    grid = np.linspace(-8.0, 8.0, 4000)
+    # densities (normalised histograms) of each sample on the shared grid
+    pa, _ = np.histogram(a, bins=np.r_[grid, grid[-1] + (grid[1] - grid[0])], density=True)
+    pb, _ = np.histogram(b, bins=np.r_[grid, grid[-1] + (grid[1] - grid[0])], density=True)
+    got = float(objectives.wasserstein_1d(jnp.asarray(pa), jnp.asarray(pb), jnp.asarray(grid)))
+    expected = float(wasserstein_distance(a, b))
+    assert np.isclose(got, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_wasserstein_1d_zero_for_identical_inputs():
+    rng = np.random.default_rng(4)
+    p = jnp.asarray(np.abs(rng.standard_normal(100)))
+    x = jnp.linspace(0.0, 5.0, 100)
+    assert float(objectives.wasserstein_1d(p, p, x)) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_wasserstein_1d_is_grad_safe():
+    rng = np.random.default_rng(5)
+    p = jnp.asarray(np.abs(rng.standard_normal(100)))
+    q = jnp.asarray(np.abs(rng.standard_normal(100)))
+    x = jnp.linspace(0.0, 5.0, 100)
+
+    def loss(scale):
+        return objectives.wasserstein_1d(scale * p, q, x)
+
+    g = jax.grad(loss)(1.0)
+    assert np.isfinite(float(g))
+
+
+def test_fcd_distribution_shape_and_normalisation(signals):
+    pred, _ = signals
+    fcd_mat = objectives.fcd(window_size=30, step_size=5)(pred)
+    midpoints = jnp.linspace(-0.99, 0.99, 100)
+    density = objectives.fcd_distribution(fcd_mat, midpoints=midpoints)
+    assert np.asarray(density).shape == (100,)
+    dx = float(midpoints[1] - midpoints[0])
+    integral = float(jnp.sum(density) * dx)
+    assert np.isclose(integral, 1.0, atol=1e-3)
+
+
+def test_fcd_distribution_default_midpoints(signals):
+    pred, _ = signals
+    fcd_mat = objectives.fcd(window_size=30, step_size=5)(pred)
+    density = objectives.fcd_distribution(fcd_mat)
+    assert np.asarray(density).shape == (100,)   # default 100-point grid
+
+
+def test_fcd_distribution_unnormalised_branch(signals):
+    pred, _ = signals
+    fcd_mat = objectives.fcd(window_size=30, step_size=5)(pred)
+    midpoints = jnp.linspace(-0.99, 0.99, 100)
+    raw = objectives.fcd_distribution(fcd_mat, midpoints=midpoints, normalize=False)
+    norm = objectives.fcd_distribution(fcd_mat, midpoints=midpoints, normalize=True)
+    dx = float(midpoints[1] - midpoints[0])
+    # The un-normalised density does not integrate to 1; normalising fixes that.
+    assert not np.isclose(float(jnp.sum(raw) * dx), 1.0, atol=1e-3)
+    assert np.isclose(float(jnp.sum(norm) * dx), 1.0, atol=1e-3)
+
+
+# --------------------------------------------------------------------------- #
+# FCD-distribution objective builders: fcd_ks / fcd_wasserstein               #
+# --------------------------------------------------------------------------- #
+
+def test_fcd_wasserstein_zero_on_identity(signals):
+    pred, _ = signals
+    loss = objectives.fcd_wasserstein(window_size=30, step_size=5)
+    assert float(loss(pred, pred)) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_fcd_ks_zero_on_identity(signals):
+    pred, _ = signals
+    loss = objectives.fcd_ks(window_size=30, step_size=5)
+    assert float(loss(pred, pred)) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_fcd_wasserstein_positive_for_different_signals(signals):
+    pred, target = signals
+    loss = objectives.fcd_wasserstein(window_size=30, step_size=5)
+    assert float(loss(pred, target)) > 0.0
+
+
+def test_fcd_ks_positive_for_different_signals(signals):
+    pred, target = signals
+    loss = objectives.fcd_ks(window_size=30, step_size=5)
+    assert float(loss(pred, target)) > 0.0
+
+
+def test_fcd_wasserstein_is_grad_safe(signals):
+    pred, target = signals
+
+    def loss(scale):
+        return objectives.fcd_wasserstein(window_size=30, step_size=5)(scale * pred, target)
+
+    g = jax.grad(loss)(1.0)
+    assert np.isfinite(float(g))
+
+
+def test_fcd_wasserstein_combines(signals):
+    pred, target = signals
+    combined = objectives.combine(
+        (1.0, objectives.timeseries_rmse()),
+        (0.5, objectives.fcd_wasserstein(window_size=30, step_size=5)),
+    )
+    got = float(combined(pred, target))
+    expected = (1.0 * float(objectives.timeseries_rmse()(pred, target))
+                + 0.5 * float(objectives.fcd_wasserstein(window_size=30, step_size=5)(pred, target)))
+    assert np.isclose(got, expected)
+
+
+@pytest.mark.parametrize('builder', [objectives.fcd_wasserstein, objectives.fcd_ks])
+def test_fcd_builders_accept_explicit_midpoints(builder, signals):
+    pred, target = signals
+    midpoints = jnp.linspace(-0.95, 0.95, 64)
+    loss = builder(window_size=30, step_size=5, midpoints=midpoints)
+    val = float(loss(pred, target))
+    assert np.isfinite(val) and val > 0.0
+
+
+def test_fcd_distribution_degenerate_constant_series_is_nan():
+    # A constant (zero-variance) series gives degenerate FCD off-diagonal values;
+    # the KDE covariance is singular, so the density -- and any distance built on
+    # it -- is nan. Documented: FCD-distribution objectives need non-degenerate,
+    # non-constant input.
+    const = jnp.ones((200, 6))
+    loss = objectives.fcd_wasserstein(window_size=30, step_size=5)
+    assert not np.isfinite(float(loss(const, const)))

--- a/brainmass/observation.py
+++ b/brainmass/observation.py
@@ -1,0 +1,612 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Convolution-based observation models (HRF kernels, HRF BOLD, temporal averaging).
+
+This module adds the *convolution* fMRI BOLD path -- a hemodynamic response
+function (HRF) kernel convolved with downsampled neural activity -- alongside the
+physiologically detailed Balloon-Windkessel ODE in
+:class:`brainmass.BOLDSignal`. It also provides :class:`TemporalAverage`, a
+windowed-mean downsampling observation that complements the point-decimation
+``Simulator(sample_every=)`` subsampling.
+
+When to use which BOLD path
+---------------------------
+- :class:`HRFBold` (this module) -- a linear convolution of neural activity with
+  a closed-form HRF kernel. Fast, simple, fully differentiable in its handful of
+  scalar parameters; the natural choice for **fitting** and for quickly turning a
+  long neural trajectory into a BOLD time series.
+- :class:`brainmass.BOLDSignal` -- the four-state Balloon-Windkessel ODE
+  (Friston et al. 2003). Physiologically detailed (vasodilatory signal, blood
+  flow, volume, deoxyhemoglobin); prefer it when biophysical realism matters.
+
+Both are kept; neither replaces the other.
+"""
+
+import math
+
+import brainunit as u
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+
+__all__ = [
+    'HRFKernel',
+    'FirstOrderVolterraHRFKernel',
+    'GammaHRFKernel',
+    'DoubleExponentialHRFKernel',
+    'MixtureOfGammasHRFKernel',
+    'TemporalAverage',
+    'HRFBold',
+]
+
+
+def _steps_per_period(period, dt):
+    """Return ``round(period / dt)`` as a concrete positive Python ``int``."""
+    ratio = float(u.get_magnitude(period / dt))
+    w = int(round(ratio))
+    if w < 1:
+        raise ValueError(
+            f"period {period} is shorter than dt {dt}; round(period/dt) = {w} "
+            "must be >= 1."
+        )
+    return w
+
+
+def _to_seconds(t):
+    """Return the time grid ``t`` as a bare magnitude in **seconds**.
+
+    A :class:`brainunit.Quantity` is converted with full unit checking; a plain
+    array is assumed to be in **milliseconds** (the tvboptim / TVB convention)
+    and divided by 1000.
+    """
+    if isinstance(t, u.Quantity):
+        return t.to_decimal(u.second)
+    return jnp.asarray(t) / 1000.0
+
+
+class HRFKernel:
+    r"""Base class for hemodynamic response function (HRF) kernels.
+
+    A kernel is a closed-form function of time :math:`h(t)` defining the
+    hemodynamic impulse response convolved with neural activity to form the BOLD
+    signal (see :class:`HRFBold`). Subclasses implement :meth:`__call__`.
+
+    Parameters
+    ----------
+    duration : brainunit.Quantity
+        Temporal support of the kernel (how far out :math:`h(t)` is evaluated
+        when building a convolution grid). Default ``20 * u.second``.
+
+    Notes
+    -----
+    Calling a kernel evaluates :math:`h(t)` on a time grid. The grid may be a
+    :class:`brainunit.Quantity` (any time unit) or a plain array, which is
+    interpreted as **milliseconds**. The returned :math:`h(t)` is a dimensionless
+    array.
+
+    See Also
+    --------
+    HRFBold : convolution BOLD observation that consumes a kernel.
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, duration=20. * u.second):
+        self.duration = duration
+
+    def __call__(self, t):
+        """Evaluate :math:`h(t)` on the time grid ``t`` (abstract)."""
+        raise NotImplementedError
+
+
+class FirstOrderVolterraHRFKernel(HRFKernel):
+    r"""First-order Volterra kernel of the hemodynamic system (TVB canonical).
+
+    The canonical damped-oscillator HRF -- the first-order Volterra kernel of the
+    Balloon/Windkessel hemodynamics (Friston et al. 2000) [1]_, ported from TVB's
+    ``FirstOrderVolterra`` equation:
+
+    .. math::
+
+        h(t) = s \, e^{-t / (2\tau_s)} \, \frac{\sin(\omega t)}{\omega},
+        \qquad
+        \omega = \sqrt{\frac{1}{\tau_f} - \frac{1}{4\tau_s^2}},
+
+    where :math:`t` is in **seconds**, :math:`\tau_s` is the signal-decay time
+    constant, :math:`\tau_f` the feedback time constant and :math:`s` an amplitude
+    scaling. This is the *underdamped* solution: :math:`\omega` is real only when
+    :math:`4\tau_s^2 > \tau_f` (the defaults satisfy this); violating it makes
+    :math:`\omega` -- and the whole kernel -- ``NaN``.
+
+    Despite the shared name of the mathematician Vito Volterra, this is unrelated
+    to Lotka-Volterra (predator-prey) dynamics.
+
+    Parameters
+    ----------
+    tau_s : float
+        Signal decay time constant in **seconds** (default ``0.8``).
+    tau_f : float
+        Feedback time constant in **seconds** (default ``0.4``).
+    scaling : float
+        Kernel amplitude scaling factor (default ``1 / 3``).
+    duration : brainunit.Quantity
+        Kernel support (default ``20 * u.second``).
+
+    References
+    ----------
+    .. [1] Friston KJ, Mechelli A, Turner R, Price CJ (2000). Nonlinear responses
+           in fMRI: the Balloon model, Volterra kernels, and other hemodynamics.
+           NeuroImage 12(4): 466-477.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainmass
+        >>> import brainunit as u
+        >>> import jax.numpy as jnp
+        >>> k = brainmass.FirstOrderVolterraHRFKernel()
+        >>> t = jnp.linspace(0., 20000., 5) * u.ms
+        >>> h = k(t)
+        >>> h.shape
+        (5,)
+        >>> float(h[0])
+        0.0
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, tau_s=0.8, tau_f=0.4, scaling=1.0 / 3.0,
+                 duration=20. * u.second):
+        super().__init__(duration=duration)
+        self.tau_s = tau_s
+        self.tau_f = tau_f
+        self.scaling = scaling
+
+    def __call__(self, t):
+        t_s = _to_seconds(t)
+        omega = jnp.sqrt(1.0 / self.tau_f - 1.0 / (4.0 * self.tau_s ** 2))
+        return (self.scaling
+                * jnp.exp(-0.5 * (t_s / self.tau_s))
+                * jnp.sin(omega * t_s) / omega)
+
+
+class GammaHRFKernel(HRFKernel):
+    r"""Gamma HRF kernel (Boynton et al. 1996).
+
+    A peak-normalised gamma probability density [1]_:
+
+    .. math::
+
+        h(t) \propto \frac{(t/\tau)^{n-1} e^{-t/\tau}}{\tau\,(n-1)!},
+
+    rescaled so its peak equals the amplitude factor :math:`a` (matching TVB's
+    ``Gamma`` equation). :math:`t` is in **seconds**.
+
+    Parameters
+    ----------
+    tau : float
+        Exponential time constant in **seconds** (default ``1.08``).
+    n : float
+        Phase-delay / shape parameter (default ``3.0``).
+    a : float
+        Amplitude after peak-normalisation (default ``0.1``).
+    duration : brainunit.Quantity
+        Kernel support (default ``20 * u.second``).
+
+    References
+    ----------
+    .. [1] Boynton GM, Engel SA, Glover GH, Heeger DJ (1996). Linear systems
+           analysis of functional magnetic resonance imaging in human V1.
+           J Neurosci 16(13): 4207-4221.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainmass
+        >>> import brainunit as u
+        >>> import jax.numpy as jnp
+        >>> k = brainmass.GammaHRFKernel()
+        >>> h = k(jnp.linspace(0., 20000., 256) * u.ms)
+        >>> bool(jnp.isclose(h.max(), 0.1, rtol=1e-5))
+        True
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, tau=1.08, n=3.0, a=0.1, duration=20. * u.second):
+        super().__init__(duration=duration)
+        self.tau = tau
+        self.n = n
+        self.a = a
+
+    def __call__(self, t):
+        t_s = _to_seconds(t)
+        factorial = math.factorial(int(self.n) - 1)
+        kernel = ((t_s / self.tau) ** (self.n - 1)
+                  * jnp.exp(-(t_s / self.tau))) / (self.tau * factorial)
+        peak = jnp.max(kernel)
+        peak = jnp.where(peak > 0, peak, 1.0)
+        return kernel / peak * self.a
+
+
+class DoubleExponentialHRFKernel(HRFKernel):
+    r"""Double-exponential (damped-oscillation difference) HRF kernel.
+
+    A difference of two damped sinusoids (Polonsky et al. 2000) [1]_:
+
+    .. math::
+
+        h(t) \propto a_1 e^{-t/\tau_1}\sin(2\pi f_1 t)
+                    - a_2 e^{-t/\tau_2}\sin(2\pi f_2 t),
+
+    peak-normalised and rescaled to amplitude :math:`a` (matching TVB's
+    ``DoubleExponential`` equation). :math:`t` is in **seconds**.
+
+    Parameters
+    ----------
+    tau_1, tau_2 : float
+        Time constants of the two exponentials in **seconds**
+        (defaults ``7.22``, ``7.4``).
+    f_1, f_2 : float
+        Frequencies of the two sinusoids in **Hz** (defaults ``0.03``, ``0.12``).
+    amp_1, amp_2 : float
+        Amplitudes of the two terms (defaults ``0.1``, ``0.1``).
+    a : float
+        Amplitude after peak-normalisation (default ``0.1``).
+    duration : brainunit.Quantity
+        Kernel support (default ``40 * u.second``).
+
+    References
+    ----------
+    .. [1] Polonsky A, Blake R, Braun J, Heeger DJ (2000). Neuronal activity in
+           human primary visual cortex correlates with perception during
+           binocular rivalry. Nat Neurosci 3(11): 1153-1159.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainmass
+        >>> import brainunit as u
+        >>> import jax.numpy as jnp
+        >>> k = brainmass.DoubleExponentialHRFKernel()
+        >>> h = k(jnp.linspace(0., 40000., 512) * u.ms)
+        >>> bool(jnp.isclose(h.max(), 0.1, rtol=1e-5))
+        True
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, tau_1=7.22, tau_2=7.4, f_1=0.03, f_2=0.12,
+                 amp_1=0.1, amp_2=0.1, a=0.1, duration=40. * u.second):
+        super().__init__(duration=duration)
+        self.tau_1 = tau_1
+        self.tau_2 = tau_2
+        self.f_1 = f_1
+        self.f_2 = f_2
+        self.amp_1 = amp_1
+        self.amp_2 = amp_2
+        self.a = a
+
+    def __call__(self, t):
+        t_s = _to_seconds(t)
+        kernel = (self.amp_1 * jnp.exp(-t_s / self.tau_1)
+                  * jnp.sin(2 * math.pi * self.f_1 * t_s)
+                  - self.amp_2 * jnp.exp(-t_s / self.tau_2)
+                  * jnp.sin(2 * math.pi * self.f_2 * t_s))
+        peak = jnp.max(kernel)
+        peak = jnp.where(peak > 0, peak, 1.0)
+        return kernel / peak * self.a
+
+
+class MixtureOfGammasHRFKernel(HRFKernel):
+    r"""Mixture-of-gammas HRF kernel (Glover 1999).
+
+    A difference of two gamma densities -- the canonical SPM-style HRF [1]_:
+
+    .. math::
+
+        h(t) = \frac{(\lambda t)^{a_1 - 1} e^{-\lambda t}}{\Gamma(a_1)}
+             - c\,\frac{(\lambda t)^{a_2 - 1} e^{-\lambda t}}{\Gamma(a_2)},
+
+    with :math:`t` in **seconds**. The first gamma models the positive BOLD peak;
+    the second, scaled by :math:`c`, the post-stimulus undershoot.
+
+    Parameters
+    ----------
+    a_1 : float
+        Shape parameter of the first (peak) gamma (default ``6.0``).
+    a_2 : float
+        Shape parameter of the second (undershoot) gamma (default ``13.0``).
+    l : float
+        Rate / inverse-scale parameter :math:`\lambda` (default ``1.0``).
+    c : float
+        Relative amplitude of the undershoot gamma (default ``0.4``).
+    duration : brainunit.Quantity
+        Kernel support (default ``20 * u.second``).
+
+    References
+    ----------
+    .. [1] Glover GH (1999). Deconvolution of impulse response in event-related
+           BOLD fMRI. NeuroImage 9(4): 416-429.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainmass
+        >>> import brainunit as u
+        >>> import jax.numpy as jnp
+        >>> k = brainmass.MixtureOfGammasHRFKernel()
+        >>> h = k(jnp.linspace(0., 20000., 256) * u.ms)
+        >>> h.shape
+        (256,)
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, a_1=6.0, a_2=13.0, l=1.0, c=0.4, duration=20. * u.second):
+        super().__init__(duration=duration)
+        self.a_1 = a_1
+        self.a_2 = a_2
+        self.l = l
+        self.c = c
+
+    def __call__(self, t):
+        t_s = _to_seconds(t)
+        g1 = jsp.special.gamma(self.a_1)
+        g2 = jsp.special.gamma(self.a_2)
+        return ((self.l * t_s) ** (self.a_1 - 1) * jnp.exp(-self.l * t_s) / g1
+                - self.c * (self.l * t_s) ** (self.a_2 - 1)
+                * jnp.exp(-self.l * t_s) / g2)
+
+
+class TemporalAverage:
+    r"""Downsample a trajectory by averaging over non-overlapping time windows.
+
+    For a window of ``w = round(period / dt)`` samples, the ``k``-th output is the
+    mean of the ``k``-th block:
+
+    .. math::
+
+        y_k = \frac{1}{w}\sum_{j=0}^{w-1} y[k\,w + j],
+        \qquad k = 0, \dots, \lfloor T / w \rfloor - 1.
+
+    Trailing samples that do not fill a complete window are dropped. The output is
+    sampled at ``period`` (i.e. ``n_win = T // w`` rows).
+
+    This is a thin, standalone observation -- it does **not** modify
+    :class:`brainmass.Simulator`. It is the *averaging* complement to the
+    point-decimation ``Simulator(sample_every=k)`` subsampling: ``sample_every``
+    keeps every ``k``-th sample, whereas :class:`TemporalAverage` averages each
+    window (smoother, anti-aliased). Apply it as a post-transform on a run
+    trajectory (``ta(res['output'], dt)``); it is also used internally by
+    :class:`HRFBold` to reduce neural activity to the convolution grid.
+
+    Parameters
+    ----------
+    period : brainunit.Quantity
+        Averaging-window length (default ``4 * u.ms``).
+
+    See Also
+    --------
+    brainmass.Simulator : ``sample_every=`` does point-decimation subsampling.
+    HRFBold : uses :class:`TemporalAverage` to build its convolution grid.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainmass
+        >>> import brainunit as u
+        >>> import jax.numpy as jnp
+        >>> signal = jnp.arange(20.).reshape(20, 1)
+        >>> ta = brainmass.TemporalAverage(period=5. * u.ms)
+        >>> y = ta(signal, dt=1. * u.ms)
+        >>> y.shape
+        (4, 1)
+        >>> [float(v) for v in y[:, 0]]
+        [2.0, 7.0, 12.0, 17.0]
+    """
+    __module__ = 'brainmass'
+
+    def __init__(self, period=4. * u.ms):
+        self.period = period
+
+    def __call__(self, signal, dt):
+        r"""Average ``signal`` over non-overlapping ``period``-wide windows.
+
+        Parameters
+        ----------
+        signal : array-like or brainunit.Quantity
+            Trajectory with time on axis 0 and arbitrary trailing dimensions,
+            shape ``(T, *rest)``.
+        dt : brainunit.Quantity
+            Sampling step of ``signal`` (the simulation time step).
+
+        Returns
+        -------
+        array-like or brainunit.Quantity
+            Windowed means, shape ``(T // w, *rest)`` where
+            ``w = round(period / dt)``. Units are preserved.
+        """
+        w = _steps_per_period(self.period, dt)
+        unit = u.get_unit(signal) if isinstance(signal, u.Quantity) else None
+        mag = u.get_magnitude(signal)
+        n_win = mag.shape[0] // w
+        trimmed = mag[:n_win * w]
+        windows = trimmed.reshape((n_win, w) + mag.shape[1:])
+        avg = jnp.mean(windows, axis=1)
+        return avg * unit if unit is not None else avg
+
+
+def _convolve_columns(sig2d, hrf, mode, method):
+    """Convolve each column of ``sig2d`` (shape ``(L, M)``) with ``hrf``."""
+    if method == 'fft':
+        def conv(col):
+            return jsp.signal.fftconvolve(col, hrf, mode=mode)
+    else:
+        def conv(col):
+            return jnp.convolve(col, hrf, mode=mode)
+    return jax.vmap(conv, in_axes=1, out_axes=1)(sig2d)
+
+
+class HRFBold:
+    r"""Convolution-based fMRI BOLD observation (HRF kernel).
+
+    Forms the BOLD signal by convolving downsampled neural activity with a
+    closed-form hemodynamic response function (HRF) kernel, then decimating to the
+    repetition time (TR). The pipeline is:
+
+    1. **Downsample** neural activity from the simulation step ``dt`` to
+       ``downsample_period`` with a :class:`TemporalAverage`.
+    2. **Convolve** each region's series (after prepending a warm-up ``history``,
+       zeros by default) with ``kernel`` evaluated on the ``downsample_period``
+       grid.
+    3. **Scale** to BOLD: :math:`\mathrm{BOLD} = k_1 V_0 (c - 1)`, where :math:`c`
+       is the convolution output (the ``-1`` removes the unit baseline, matching
+       the TVB convention).
+    4. **Decimate** to the TR by taking every ``round(period / downsample_period)``
+       sample.
+
+    Unlike the four-state Balloon-Windkessel ODE in :class:`brainmass.BOLDSignal`,
+    this is a single linear convolution -- fast, simple and fully differentiable in
+    its scalar parameters, which makes it the natural choice for **fitting**.
+    Prefer :class:`brainmass.BOLDSignal` when biophysical realism matters. Both are
+    kept.
+
+    Parameters
+    ----------
+    k_1 : float
+        BOLD signal scaling factor (default ``5.6``).
+    V_0 : float
+        Resting blood volume fraction (default ``0.02``).
+    period : brainunit.Quantity
+        Final BOLD sampling period / TR (default ``1000 * u.ms``).
+    downsample_period : brainunit.Quantity
+        Intermediate downsampling period the kernel is sampled on
+        (default ``4 * u.ms``).
+    kernel : HRFKernel
+        HRF kernel to convolve with (default
+        :class:`FirstOrderVolterraHRFKernel`).
+    convolution_mode : {'valid', 'same', 'full'}
+        Convolution edge mode (default ``'valid'``; with the zero ``history``
+        prepend this yields a causal output of length ``T_ds + 1``).
+    method : {'fft', 'direct'}
+        ``'fft'`` uses :func:`jax.scipy.signal.fftconvolve`; ``'direct'`` uses
+        :func:`jax.numpy.convolve`. They agree numerically (default ``'fft'``).
+    history : array-like, optional
+        Warm-up buffer prepended before convolution, shape
+        ``(round(duration / downsample_period), *regions)``. ``None`` (default)
+        prepends zeros.
+
+    See Also
+    --------
+    brainmass.BOLDSignal : the physiologically detailed Balloon-Windkessel ODE BOLD.
+    TemporalAverage : the windowed-mean downsampler used internally.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainmass
+        >>> import brainunit as u
+        >>> import jax.numpy as jnp
+        >>> t = jnp.arange(2000.)
+        >>> z = 1.0 + 0.5 * jnp.sin(2 * jnp.pi * t[:, None] / 800.0)
+        >>> bold = brainmass.HRFBold(
+        ...     period=200. * u.ms, downsample_period=4. * u.ms,
+        ...     kernel=brainmass.FirstOrderVolterraHRFKernel(duration=400. * u.ms),
+        ... )
+        >>> y = bold(z, dt=1. * u.ms)
+        >>> y.shape[1]
+        1
+    """
+    __module__ = 'brainmass'
+
+    def __init__(
+        self,
+        k_1=5.6,
+        V_0=0.02,
+        period=1000. * u.ms,
+        downsample_period=4. * u.ms,
+        kernel=None,
+        convolution_mode='valid',
+        method='fft',
+        history=None,
+    ):
+        if convolution_mode not in ('valid', 'same', 'full'):
+            raise ValueError(
+                f"convolution_mode must be 'valid', 'same' or 'full', got "
+                f"{convolution_mode!r}."
+            )
+        if method not in ('fft', 'direct'):
+            raise ValueError(f"method must be 'fft' or 'direct', got {method!r}.")
+        self.k_1 = k_1
+        self.V_0 = V_0
+        self.period = period
+        self.downsample_period = downsample_period
+        self.kernel = kernel if kernel is not None else FirstOrderVolterraHRFKernel()
+        self.convolution_mode = convolution_mode
+        self.method = method
+        self.history = history
+        self._downsampler = TemporalAverage(period=downsample_period)
+
+    def __call__(self, signal, dt):
+        r"""Map a neural-activity trajectory to a BOLD time series.
+
+        Parameters
+        ----------
+        signal : array-like or brainunit.Quantity
+            Neural-activity proxy with time on axis 0, shape ``(T, *regions)``.
+            Only its magnitude is used (BOLD is a normalised observable).
+        dt : brainunit.Quantity
+            Simulation time step of ``signal``.
+
+        Returns
+        -------
+        jax.Array
+            Dimensionless BOLD signal sampled at ``period``, shape
+            ``(T_bold, *regions)``.
+        """
+        # 1) downsample neural activity to the convolution grid (magnitude only)
+        ys = u.get_magnitude(self._downsampler(signal, dt))
+        rest = ys.shape[1:]
+
+        # 2) HRF kernel evaluated on the downsample grid
+        dur_ms = float(self.kernel.duration.to_decimal(u.ms))
+        ksamp = int(math.ceil(
+            float(u.get_magnitude(self.kernel.duration / self.downsample_period))
+        ))
+        kernel_time = jnp.linspace(0.0, dur_ms, ksamp) * u.ms
+        hrf = self.kernel(kernel_time)
+
+        # 3) prepend warm-up history (zeros by default)
+        if self.history is None:
+            pad = jnp.zeros((ksamp,) + rest, dtype=ys.dtype)
+        else:
+            pad = u.get_magnitude(self.history)
+        ys_h = jnp.concatenate([pad, ys], axis=0)
+
+        # 4) convolve each region column with the kernel
+        sig2d = ys_h.reshape(ys_h.shape[0], -1)
+        conv = _convolve_columns(sig2d, hrf, self.convolution_mode, self.method)
+
+        # 5) BOLD scaling (the -1 removes the unit baseline, TVB convention)
+        bold = self.k_1 * self.V_0 * (conv - 1.0)
+
+        # 6) decimate to the TR
+        step = _steps_per_period(self.period, self.downsample_period)
+        idx = jnp.arange(step, bold.shape[0], step)
+        bold = bold[idx]
+        return bold.reshape((bold.shape[0],) + rest)

--- a/brainmass/observation_test.py
+++ b/brainmass/observation_test.py
@@ -1,0 +1,492 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for :mod:`brainmass.observation`.
+
+The HRF kernels are validated against *embedded* verbatim transcriptions of
+tvboptim's closed-form kernel maths (the embedded-reference-oracle pattern from
+goals 09/10 -- always-on, no live ``tvboptim`` import), plus the analytic
+properties each kernel must satisfy (``h(0) == 0``, peak normalisation, real
+underdamped frequency), unit-awareness, gradient-safety, and vmap-safety.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+import numpy as np
+import pytest
+
+import brainunit as u
+
+from brainmass import observation
+
+
+# --------------------------------------------------------------------------- #
+# Embedded tvboptim kernel oracles (verbatim closed forms; t in milliseconds)  #
+# --------------------------------------------------------------------------- #
+
+def _ref_first_order_volterra(t_ms, tau_s=0.8, tau_f=0.4, scaling=1.0 / 3.0):
+    t_s = t_ms / 1000.0
+    omega = jnp.sqrt(1.0 / tau_f - 1.0 / (4.0 * tau_s ** 2))
+    return scaling * jnp.exp(-0.5 * (t_s / tau_s)) * jnp.sin(omega * t_s) / omega
+
+
+def _ref_gamma(t_ms, tau=1.08, n=3.0, a=0.1):
+    t_s = t_ms / 1000.0
+    factorial = math.factorial(int(n) - 1)
+    kernel = ((t_s / tau) ** (n - 1) * jnp.exp(-(t_s / tau))) / (tau * factorial)
+    peak = jnp.max(kernel)
+    peak = jnp.where(peak > 0, peak, 1.0)
+    return kernel / peak * a
+
+
+def _ref_double_exp(t_ms, tau_1=7.22, tau_2=7.4, f_1=0.03, f_2=0.12,
+                    amp_1=0.1, amp_2=0.1, a=0.1):
+    t_s = t_ms / 1000.0
+    kernel = (amp_1 * jnp.exp(-t_s / tau_1) * jnp.sin(2 * math.pi * f_1 * t_s)
+              - amp_2 * jnp.exp(-t_s / tau_2) * jnp.sin(2 * math.pi * f_2 * t_s))
+    peak = jnp.max(kernel)
+    peak = jnp.where(peak > 0, peak, 1.0)
+    return kernel / peak * a
+
+
+def _ref_mixture_gammas(t_ms, a_1=6.0, a_2=13.0, l=1.0, c=0.4):
+    t_s = t_ms / 1000.0
+    g1 = jsp.special.gamma(a_1)
+    g2 = jsp.special.gamma(a_2)
+    return ((l * t_s) ** (a_1 - 1) * jnp.exp(-l * t_s) / g1
+            - c * (l * t_s) ** (a_2 - 1) * jnp.exp(-l * t_s) / g2)
+
+
+@pytest.fixture
+def grid_ms():
+    """A fixed time grid in milliseconds spanning a 20 s kernel support."""
+    return jnp.linspace(0.0, 20_000.0, 256)
+
+
+_KERNELS = [
+    (observation.FirstOrderVolterraHRFKernel, _ref_first_order_volterra),
+    (observation.GammaHRFKernel, _ref_gamma),
+    (observation.DoubleExponentialHRFKernel, _ref_double_exp),
+    (observation.MixtureOfGammasHRFKernel, _ref_mixture_gammas),
+]
+
+
+# --------------------------------------------------------------------------- #
+# Closed-form / embedded-oracle equality                                       #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize('kernel_cls, ref', _KERNELS)
+def test_kernel_matches_embedded_oracle(kernel_cls, ref, grid_ms):
+    got = kernel_cls()(grid_ms * u.ms)
+    expected = ref(grid_ms)
+    assert np.allclose(np.asarray(got), np.asarray(expected), rtol=1e-6, atol=1e-8)
+
+
+@pytest.mark.parametrize('kernel_cls, ref', _KERNELS)
+def test_kernel_returns_dimensionless(kernel_cls, ref, grid_ms):
+    got = kernel_cls()(grid_ms * u.ms)
+    # h(t) is a dimensionless array, not a Quantity.
+    assert not isinstance(got, u.Quantity)
+    assert np.asarray(got).shape == (grid_ms.shape[0],)
+
+
+@pytest.mark.parametrize('kernel_cls, ref', _KERNELS)
+def test_kernel_is_zero_at_origin(kernel_cls, ref, grid_ms):
+    got = kernel_cls()(grid_ms * u.ms)
+    assert np.isclose(float(np.asarray(got)[0]), 0.0, atol=1e-8)
+
+
+def test_gamma_peak_equals_amplitude(grid_ms):
+    k = observation.GammaHRFKernel(a=0.1)
+    got = np.asarray(k(grid_ms * u.ms))
+    assert np.isclose(got.max(), 0.1, rtol=1e-6)
+
+
+def test_double_exp_peak_equals_amplitude(grid_ms):
+    k = observation.DoubleExponentialHRFKernel(a=0.1)
+    got = np.asarray(k(grid_ms * u.ms))
+    assert np.isclose(got.max(), 0.1, rtol=1e-6)
+
+
+def test_first_order_volterra_omega_is_real():
+    # Defaults satisfy 4*tau_s**2 > tau_f so the underdamped omega is real.
+    k = observation.FirstOrderVolterraHRFKernel()
+    omega = math.sqrt(1.0 / k.tau_f - 1.0 / (4.0 * k.tau_s ** 2))
+    assert omega > 0
+
+
+# --------------------------------------------------------------------------- #
+# Unit awareness                                                                #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize('kernel_cls, ref', _KERNELS)
+def test_kernel_unit_aware_ms_vs_seconds(kernel_cls, ref, grid_ms):
+    k = kernel_cls()
+    h_ms = np.asarray(k(grid_ms * u.ms))
+    h_s = np.asarray(k((grid_ms / 1000.0) * u.second))
+    assert np.allclose(h_ms, h_s, rtol=1e-6, atol=1e-8)
+
+
+@pytest.mark.parametrize('kernel_cls, ref', _KERNELS)
+def test_kernel_plain_array_is_milliseconds(kernel_cls, ref, grid_ms):
+    k = kernel_cls()
+    h_plain = np.asarray(k(grid_ms))          # plain array assumed ms
+    h_quant = np.asarray(k(grid_ms * u.ms))
+    assert np.allclose(h_plain, h_quant, rtol=1e-6, atol=1e-8)
+
+
+# --------------------------------------------------------------------------- #
+# Gradient- and vmap-safety                                                     #
+# --------------------------------------------------------------------------- #
+
+def test_first_order_volterra_grad_through_tau_s(grid_ms):
+    def loss(tau_s):
+        k = observation.FirstOrderVolterraHRFKernel(tau_s=tau_s)
+        return jnp.sum(k(grid_ms * u.ms))
+
+    g = jax.grad(loss)(0.8)
+    assert np.isfinite(float(g))
+    assert float(g) != 0.0
+
+
+def test_gamma_grad_through_tau(grid_ms):
+    def loss(tau):
+        return jnp.sum(observation.GammaHRFKernel(tau=tau)(grid_ms * u.ms))
+
+    g = jax.grad(loss)(1.08)
+    assert np.isfinite(float(g))
+
+
+def test_mixture_gammas_grad_through_lambda(grid_ms):
+    def loss(l):
+        return jnp.sum(observation.MixtureOfGammasHRFKernel(l=l)(grid_ms * u.ms))
+
+    g = jax.grad(loss)(1.0)
+    assert np.isfinite(float(g))
+
+
+@pytest.mark.parametrize('kernel_cls, ref', _KERNELS)
+def test_kernel_vmap_over_grids(kernel_cls, ref, grid_ms):
+    k = kernel_cls()
+    grids = jnp.stack([grid_ms, grid_ms * 0.5]) * u.ms
+    out = jax.vmap(k)(grids)
+    assert np.asarray(out).shape == (2, grid_ms.shape[0])
+    assert np.allclose(np.asarray(out)[0], np.asarray(k(grid_ms * u.ms)),
+                       rtol=1e-6, atol=1e-8)
+
+
+def test_base_kernel_is_abstract(grid_ms):
+    with pytest.raises(NotImplementedError):
+        observation.HRFKernel()(grid_ms * u.ms)
+
+
+# --------------------------------------------------------------------------- #
+# TemporalAverage                                                              #
+# --------------------------------------------------------------------------- #
+
+def test_temporal_average_matches_manual_window_mean():
+    rng = np.random.default_rng(0)
+    signal = jnp.asarray(rng.standard_normal((40, 3)))
+    avg = observation.TemporalAverage(period=4. * u.ms)(signal, dt=1. * u.ms)
+    # w = 4, n_win = 10; y[k] = mean(signal[4k:4k+4]).
+    expected = np.asarray(signal).reshape(10, 4, 3).mean(axis=1)
+    assert np.asarray(avg).shape == (10, 3)
+    assert np.allclose(np.asarray(avg), expected)
+
+
+def test_temporal_average_drops_trailing_partial_window():
+    signal = jnp.arange(43. * 2).reshape(43, 2)
+    avg = observation.TemporalAverage(period=4. * u.ms)(signal, dt=1. * u.ms)
+    # 43 // 4 = 10 complete windows; the final 3 samples are dropped.
+    assert np.asarray(avg).shape == (10, 2)
+    expected = np.asarray(signal)[:40].reshape(10, 4, 2).mean(axis=1)
+    assert np.allclose(np.asarray(avg), expected)
+
+
+def test_temporal_average_non_integer_period_rounds():
+    signal = jnp.arange(100.).reshape(100, 1)
+    # period/dt = 4 / 0.3 = 13.33 -> w = round(13.33) = 13; n_win = 100 // 13 = 7.
+    avg = observation.TemporalAverage(period=4. * u.ms)(signal, dt=0.3 * u.ms)
+    assert np.asarray(avg).shape == (7, 1)
+    expected = np.asarray(signal)[:91].reshape(7, 13, 1).mean(axis=1)
+    assert np.allclose(np.asarray(avg), expected)
+
+
+def test_temporal_average_preserves_units():
+    signal = jnp.ones((20, 2)) * u.mV
+    avg = observation.TemporalAverage(period=5. * u.ms)(signal, dt=1. * u.ms)
+    assert isinstance(avg, u.Quantity)
+    assert avg.unit == u.mV
+    assert np.allclose(np.asarray(u.get_magnitude(avg)), 1.0)
+
+
+def test_temporal_average_1d_signal():
+    signal = jnp.arange(20.)
+    avg = observation.TemporalAverage(period=5. * u.ms)(signal, dt=1. * u.ms)
+    assert np.asarray(avg).shape == (4,)
+    expected = np.asarray(signal).reshape(4, 5).mean(axis=1)
+    assert np.allclose(np.asarray(avg), expected)
+
+
+def test_temporal_average_batched_trailing_dims():
+    signal = jnp.ones((30, 4, 5))
+    avg = observation.TemporalAverage(period=3. * u.ms)(signal, dt=1. * u.ms)
+    assert np.asarray(avg).shape == (10, 4, 5)
+
+
+def test_temporal_average_jit_safe():
+    signal = jnp.ones((30, 2))
+    ta = observation.TemporalAverage(period=3. * u.ms)
+    fn = jax.jit(lambda s: ta(s, dt=1. * u.ms))
+    assert np.asarray(fn(signal)).shape == (10, 2)
+
+
+def test_temporal_average_period_shorter_than_dt_raises():
+    # round(period/dt) = round(0.5) = 0 -> a window narrower than one sample.
+    signal = jnp.ones((10, 1))
+    with pytest.raises(ValueError):
+        observation.TemporalAverage(period=1. * u.ms)(signal, dt=2. * u.ms)
+
+
+# --------------------------------------------------------------------------- #
+# HRFBold -- independent numpy/scipy oracle                                    #
+# --------------------------------------------------------------------------- #
+
+from scipy.signal import fftconvolve as _scipy_fftconvolve  # noqa: E402
+
+
+def _ref_hrfbold(signal, dt_ms, kernel, k_1=5.6, V_0=0.02, period_ms=1000.,
+                 downsample_ms=4., mode='valid', history=None):
+    """Independent numpy/scipy reproduction of the HRFBold pipeline."""
+    sig = np.asarray(u.get_magnitude(signal), dtype=np.float64)
+    rest = sig.shape[1:]
+    # 1) temporal-average downsample dt -> downsample_period
+    w = int(round(downsample_ms / dt_ms))
+    n_win = sig.shape[0] // w
+    ys = sig[:n_win * w].reshape((n_win, w) + rest).mean(axis=1)
+    # 2) HRF kernel on the downsample grid
+    dur_ms = float(kernel.duration.to_decimal(u.ms))
+    ksamp = int(math.ceil(dur_ms / downsample_ms))
+    ktime = np.linspace(0.0, dur_ms, ksamp)
+    hrf = np.asarray(kernel(ktime), dtype=np.float64)
+    # 3) prepend history (zeros by default)
+    if history is None:
+        pad = np.zeros((ksamp,) + rest, dtype=np.float64)
+    else:
+        pad = np.asarray(u.get_magnitude(history), dtype=np.float64)
+    ysh = np.concatenate([pad, ys], axis=0)
+    # 4) convolve each column independently with scipy
+    cols = ysh.reshape(ysh.shape[0], -1)
+    out = np.stack(
+        [_scipy_fftconvolve(cols[:, j], hrf, mode=mode) for j in range(cols.shape[1])],
+        axis=1,
+    )
+    # 5) BOLD scaling
+    bold = k_1 * V_0 * (out - 1.0)
+    # 6) decimate to TR
+    step = int(round(period_ms / downsample_ms))
+    idx = np.arange(step, bold.shape[0], step)
+    return bold[idx].reshape((-1,) + rest)
+
+
+@pytest.fixture
+def neural_signal():
+    """A slow multi-region neural drive sampled at dt = 1 ms."""
+    t = jnp.arange(2000.)            # 2000 ms at dt=1ms
+    phases = jnp.asarray([0.0, 0.6, 1.2])
+    sig = 1.0 + 0.5 * jnp.sin(2 * jnp.pi * t[:, None] / 800.0 + phases[None, :])
+    return sig                       # (2000, 3), hovers around 1
+
+
+@pytest.fixture
+def small_kernel():
+    return observation.FirstOrderVolterraHRFKernel(duration=400. * u.ms)
+
+
+def test_hrfbold_matches_independent_oracle(neural_signal, small_kernel):
+    bold = observation.HRFBold(
+        period=200. * u.ms, downsample_period=4. * u.ms, kernel=small_kernel,
+    )
+    got = bold(neural_signal, dt=1. * u.ms)
+    expected = _ref_hrfbold(neural_signal, 1.0, small_kernel,
+                            period_ms=200., downsample_ms=4., mode='valid')
+    assert np.asarray(got).shape == expected.shape
+    assert np.allclose(np.asarray(got), expected, rtol=1e-4, atol=1e-5)
+
+
+def test_hrfbold_fft_equals_direct(neural_signal, small_kernel):
+    bold_fft = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                                   kernel=small_kernel, method='fft')
+    bold_dir = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                                   kernel=small_kernel, method='direct')
+    a = np.asarray(bold_fft(neural_signal, dt=1. * u.ms))
+    b = np.asarray(bold_dir(neural_signal, dt=1. * u.ms))
+    assert a.shape == b.shape
+    assert np.allclose(a, b, rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.parametrize('mode', ['valid', 'same', 'full'])
+def test_hrfbold_conv_modes_run(neural_signal, small_kernel, mode):
+    bold = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                               kernel=small_kernel, convolution_mode=mode)
+    got = np.asarray(bold(neural_signal, dt=1. * u.ms))
+    expected = _ref_hrfbold(neural_signal, 1.0, small_kernel,
+                            period_ms=200., downsample_ms=4., mode=mode)
+    assert got.shape == expected.shape
+    assert np.allclose(got, expected, rtol=1e-4, atol=1e-5)
+
+
+def test_hrfbold_preserves_region_dimension(neural_signal, small_kernel):
+    bold = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                               kernel=small_kernel)
+    got = np.asarray(bold(neural_signal, dt=1. * u.ms))
+    assert got.ndim == 2
+    assert got.shape[1] == 3          # regions preserved
+
+
+def test_hrfbold_grad_through_k1(neural_signal, small_kernel):
+    def loss(k_1):
+        bold = observation.HRFBold(k_1=k_1, period=200. * u.ms,
+                                   downsample_period=4. * u.ms, kernel=small_kernel)
+        return jnp.sum(bold(neural_signal, dt=1. * u.ms))
+
+    g = jax.grad(loss)(5.6)
+    assert np.isfinite(float(g))
+    assert float(g) != 0.0
+
+
+def test_hrfbold_grad_through_kernel_param(neural_signal):
+    def loss(tau_s):
+        kernel = observation.FirstOrderVolterraHRFKernel(tau_s=tau_s,
+                                                         duration=400. * u.ms)
+        bold = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                                   kernel=kernel)
+        return jnp.sum(bold(neural_signal, dt=1. * u.ms))
+
+    g = jax.grad(loss)(0.8)
+    assert np.isfinite(float(g))
+
+
+def test_hrfbold_batched_via_vmap(neural_signal, small_kernel):
+    batch = jnp.stack([neural_signal, neural_signal * 1.1])  # (2, 2000, 3)
+    bold = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                               kernel=small_kernel)
+    out = jax.vmap(lambda s: bold(s, dt=1. * u.ms))(batch)
+    single = np.asarray(bold(neural_signal, dt=1. * u.ms))
+    assert np.asarray(out).shape == (2,) + single.shape
+    assert np.allclose(np.asarray(out)[0], single, rtol=1e-4, atol=1e-5)
+
+
+def test_hrfbold_history_warm_start_changes_output(neural_signal, small_kernel):
+    ksamp = int(math.ceil(400. / 4.))            # kernel samples on 4 ms grid
+    history = jnp.ones((ksamp, 3))               # non-zero warm-start
+    bold_hist = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                                    kernel=small_kernel, history=history)
+    bold_zero = observation.HRFBold(period=200. * u.ms, downsample_period=4. * u.ms,
+                                    kernel=small_kernel)
+    a = np.asarray(bold_hist(neural_signal, dt=1. * u.ms))
+    b = np.asarray(bold_zero(neural_signal, dt=1. * u.ms))
+    expected = _ref_hrfbold(neural_signal, 1.0, small_kernel, period_ms=200.,
+                            downsample_ms=4., mode='valid', history=history)
+    assert a.shape == expected.shape
+    assert np.allclose(a, expected, rtol=1e-4, atol=1e-5)
+    assert not np.allclose(a, b)                 # history changes the result
+
+
+def test_hrfbold_invalid_convolution_mode_raises():
+    with pytest.raises(ValueError):
+        observation.HRFBold(convolution_mode='nope')
+
+
+def test_hrfbold_invalid_method_raises():
+    with pytest.raises(ValueError):
+        observation.HRFBold(method='nope')
+
+
+def test_hrfbold_default_kernel_is_first_order_volterra():
+    bold = observation.HRFBold()
+    assert isinstance(bold.kernel, observation.FirstOrderVolterraHRFKernel)
+
+
+def test_hrfbold_downsample_period_not_multiple_of_dt(neural_signal, small_kernel):
+    # downsample_period/dt = 4 / 0.3 = 13.33 -> rounds to 13; must still run.
+    bold = observation.HRFBold(period=100. * u.ms, downsample_period=4. * u.ms,
+                               kernel=small_kernel)
+    got = np.asarray(bold(neural_signal, dt=0.3 * u.ms))
+    expected = _ref_hrfbold(neural_signal, 0.3, small_kernel, period_ms=100.,
+                            downsample_ms=4., mode='valid')
+    assert got.shape == expected.shape
+    assert np.allclose(got, expected, rtol=1e-4, atol=1e-5)
+
+
+def test_hrfbold_correlates_with_balloon_windkessel():
+    """Qualitative: convolution BOLD tracks the Balloon-Windkessel ODE BOLD.
+
+    The Balloon-Windkessel ODE is dimensionless and integrated with a *unitless*
+    ``dt`` (seconds); ``HRFBold`` receives the matching real-time step as a
+    Quantity (0.01 s == 10 ms). Both are driven by the same slow neural drive.
+    """
+    import brainmass
+    import brainstate
+
+    brainstate.random.seed(0)
+    dt_bw = 0.01                        # seconds, unitless (BW ODE is dimensionless)
+    n_steps = 6000                      # 60 s
+    t_s = jnp.arange(n_steps) * dt_bw   # seconds
+    # slow neural oscillation (period 20 s) hovering around 1
+    z = 1.0 + 0.4 * jnp.sin(2 * jnp.pi * t_s / 20.0)
+    z = jnp.broadcast_to(z[:, None], (n_steps, 1))
+
+    # Balloon-Windkessel ODE BOLD (unitless dt)
+    balloon = brainmass.BOLDSignal(in_size=1)
+    with brainstate.environ.context(dt=dt_bw):
+        brainstate.nn.init_all_states(balloon)
+
+        def bw_step(i):
+            balloon.update(z[i])
+            return balloon.bold()
+
+        balloon_bold = brainstate.transform.for_loop(bw_step, jnp.arange(n_steps))
+    balloon_bold = np.asarray(u.get_magnitude(balloon_bold)).reshape(-1)
+
+    # convolution BOLD on the same drive, real-time dt = 10 ms, TR = 1 s
+    dt_q = 10. * u.ms
+    hrf = observation.HRFBold(
+        period=1000. * u.ms, downsample_period=20. * u.ms,
+        kernel=observation.FirstOrderVolterraHRFKernel(duration=20000. * u.ms),
+    )
+    hrf_bold = np.asarray(hrf(z, dt=dt_q)).reshape(-1)
+
+    # downsample the balloon BOLD to the same TR and align lengths
+    balloon_tr = np.asarray(
+        observation.TemporalAverage(period=1000. * u.ms)(
+            jnp.asarray(balloon_bold)[:, None], dt=dt_q
+        )
+    ).reshape(-1)
+    n = min(len(balloon_tr), len(hrf_bold))
+    # drop the first few TRs (hemodynamic warm-up) before correlating
+    a, b = balloon_tr[5:n], hrf_bold[5:n]
+    # The two hemodynamic models have different intrinsic latencies, so compare
+    # them up to a hemodynamic lag (best correlation over +/- 6 TR shifts) -- the
+    # standard way to compare BOLD waveforms with differing peak delays.
+    best = max(
+        np.corrcoef(a[lag:], b[:len(b) - lag])[0, 1] if lag >= 0
+        else np.corrcoef(a[:len(a) + lag], b[-lag:])[0, 1]
+        for lag in range(-6, 7)
+    )
+    assert best > 0.9

--- a/docs/apis/forward.rst
+++ b/docs/apis/forward.rst
@@ -133,6 +133,105 @@ BOLD signals are typically acquired at TR ~ 1-2 seconds. Downsample high-frequen
    bold_downsampled = bold_signal[::downsample_factor]
 
 
+Convolution-based BOLD (HRF kernels)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   HRFBold
+   HRFKernel
+   FirstOrderVolterraHRFKernel
+   GammaHRFKernel
+   DoubleExponentialHRFKernel
+   MixtureOfGammasHRFKernel
+
+:class:`HRFBold` is a second, complementary BOLD path: instead of integrating the
+four-state Balloon-Windkessel ODE, it **convolves** downsampled neural activity
+with a closed-form hemodynamic response function (HRF) kernel, then decimates to
+the repetition time (TR):
+
+.. math::
+
+   \text{BOLD} = k_1 V_0 \,(\,h * y_{\text{ds}} - 1\,),
+
+where :math:`y_{\text{ds}}` is the temporally-averaged neural activity, :math:`h`
+the HRF kernel and :math:`*` 1-D convolution along time.
+
+**When to use which BOLD path:**
+
+.. list-table::
+   :widths: 22 39 39
+   :header-rows: 1
+
+   * - Aspect
+     - :class:`HRFBold` (convolution)
+     - :class:`BOLDSignal` (Balloon-Windkessel)
+   * - Form
+     - Single linear convolution with an HRF kernel
+     - Four-state nonlinear hemodynamic ODE
+   * - Strengths
+     - Fast, simple, differentiable in its few scalar parameters
+     - Physiologically detailed (flow, volume, deoxyhemoglobin)
+   * - Prefer for
+     - **Fitting** / quick BOLD from a long neural trajectory
+     - Biophysical realism
+
+Both are kept; neither replaces the other.
+
+**HRF kernel family.** Four closed-form kernels (each a callable ``kernel(t)``
+returning a dimensionless :math:`h(t)`; ``t`` is a time :class:`~brainunit.Quantity`,
+or a plain array interpreted as milliseconds):
+
+- :class:`FirstOrderVolterraHRFKernel` -- TVB canonical underdamped damped-oscillator
+  (Friston et al. 2000).
+- :class:`GammaHRFKernel` -- peak-normalised gamma pdf (Boynton et al. 1996).
+- :class:`DoubleExponentialHRFKernel` -- damped-oscillation difference (Polonsky et al. 2000).
+- :class:`MixtureOfGammasHRFKernel` -- difference of gammas / SPM canonical (Glover 1999).
+
+**Example:**
+
+>>> import brainmass
+>>> import brainunit as u
+>>> import jax.numpy as jnp
+>>> t = jnp.arange(2000.)
+>>> z = 1.0 + 0.5 * jnp.sin(2 * jnp.pi * t[:, None] / 800.0)   # slow neural drive
+>>> bold = brainmass.HRFBold(
+...     period=200. * u.ms, downsample_period=4. * u.ms,
+...     kernel=brainmass.FirstOrderVolterraHRFKernel(duration=400. * u.ms),
+... )
+>>> y = bold(z, dt=1. * u.ms)
+>>> y.shape[1]
+1
+
+
+Temporal Averaging
+^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   TemporalAverage
+
+:class:`TemporalAverage` downsamples a trajectory by averaging over non-overlapping
+windows of ``w = round(period / dt)`` samples (``y[k] = mean(signal[k*w : (k+1)*w])``;
+trailing partial windows are dropped). It is the **averaging** complement to the
+point-decimation ``Simulator(sample_every=k)`` subsampling -- smoother and
+anti-aliased -- and is the downsampler :class:`HRFBold` uses internally. Apply it as
+a post-transform on a run trajectory:
+
+>>> import brainmass
+>>> import brainunit as u
+>>> import jax.numpy as jnp
+>>> signal = jnp.arange(20.).reshape(20, 1)
+>>> brainmass.TemporalAverage(period=5. * u.ms)(signal, dt=1. * u.ms).shape
+(4, 1)
+
+
 EEG/MEG Lead-Field Models
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/apis/orchestration.rst
+++ b/docs/apis/orchestration.rst
@@ -82,6 +82,11 @@ reimplementing any metric maths. The callables are designed to be composed via
    fc_rmse
    cosine_sim
    fcd
+   fcd_distribution
+   ks_distance
+   wasserstein_1d
+   fcd_ks
+   fcd_wasserstein
    combine
 
 .. autofunction:: timeseries_rmse
@@ -95,6 +100,32 @@ reimplementing any metric maths. The callables are designed to be composed via
 .. autofunction:: fcd
 
 .. autofunction:: combine
+
+
+FCD-distribution objectives
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The standard FCD fitting target is the *distribution* of the FCD matrix's
+off-diagonal values, not the matrix correlation (:func:`fcd`). These builders
+compare that distribution between prediction and target: each computes the FCD of
+both, kernel-density-estimates the off-diagonal values onto a shared grid, and
+returns a distributional distance.
+
+:func:`wasserstein_1d` is **smooth and differentiable**, so :func:`fcd_wasserstein`
+is the recommended FCD objective for gradient-based fitting; :func:`ks_distance`
+(the literature-standard Kolmogorov-Smirnov statistic) is a non-smooth supremum, so
+:func:`fcd_ks` is best for evaluation / reporting. A degenerate (constant,
+zero-variance) input yields a singular KDE and a ``nan`` distance.
+
+.. autofunction:: fcd_distribution
+
+.. autofunction:: ks_distance
+
+.. autofunction:: wasserstein_1d
+
+.. autofunction:: fcd_ks
+
+.. autofunction:: fcd_wasserstein
 
 
 See Also

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,7 @@ matplotlib
 # nevergrad; it is only a braintools "testing" extra, so install it explicitly
 # for the brainmass test suite and the doctest examples.
 nevergrad
+# scipy is a transitive braintools dependency, but the FCD-distribution objective
+# tests (goal-12) cross-check ks_distance / wasserstein_1d against
+# scipy.stats.ks_2samp / wasserstein_distance, so depend on it explicitly.
+scipy


### PR DESCRIPTION
## Summary

Closes the **observation** gap vs tvboptim (sub-project F). Additive, thin, delegation-first; the existing Balloon-Windkessel `BOLDSignal` and EEG/MEG lead fields are **untouched**.

New module `brainmass/observation.py` (+ `observation_test.py`, **100% cov**):
- **HRF kernel family** — `HRFKernel` base + 4 closed-form kernels: `FirstOrderVolterraHRFKernel` (Friston 2000), `GammaHRFKernel` (Boynton 1996), `DoubleExponentialHRFKernel` (Polonsky 2000), `MixtureOfGammasHRFKernel` (Glover 1999). Unit-aware callables returning `h(t)`.
- **`HRFBold`** — convolution BOLD: downsample → convolve with kernel → `k1·V0·(·−1)` → decimate to TR. Fast, differentiable; the choice for *fitting* (vs the physiologically detailed `BOLDSignal` ODE). Documented when-to-use in both classes + a docs table.
- **`TemporalAverage`** — standalone windowed-mean monitor; the *averaging* complement to `Simulator(sample_every=)` decimation (does **not** modify `Simulator`).

Extended `brainmass/objectives.py` (**100% cov**) with the FCD-*distribution* objectives (the standard FCD fitting target = the distribution of FCD off-diagonal values, not the matrix correlation `fcd` already had):
- primitives `fcd_distribution` (KDE), `ks_distance`, `wasserstein_1d`;
- builders `fcd_ks` / `fcd_wasserstein`. **Wasserstein is smooth/grad-friendly → recommended for fitting; KS is a non-smooth `max` → for evaluation.**

## Delegation audit
- **Reused** `braintools.metric.functional_connectivity_dynamics` (FCD matrix).
- **Delegated to jax:** KDE → `jax.scipy.stats.gaussian_kde`; conv → `jax.scipy.signal.fftconvolve` / `jnp.convolve` (braintools has none).
- **Hand-implemented** only the genuine gap: `ks_distance`, `wasserstein_1d` (tiny cumsum forms).

## Validation
- HRF kernels vs **embedded verbatim transcriptions** of tvboptim's closed forms + analytic props (`h(0)=0`, peak=`a`, real underdamped ω).
- `HRFBold` vs an **independent numpy + `scipy.signal.fftconvolve`** reproduction; FFT≡direct; conv modes; history; **best-lag corr 0.98** with `BOLDSignal` on a slow drive; grad flows.
- FCD objectives: `ks_distance` **exact** vs `scipy.stats.ks_2samp`; `wasserstein_1d` ≈ `scipy.stats.wasserstein_distance`; grad flows through `fcd_wasserstein`; degenerate FCD → `nan` (documented).
- Units / shape / dtype / batched throughout; seeded.

Full suite **630 passed**; `observation.py` and `objectives.py` both **100%** covered. Docs extended (`forward.rst`, `orchestration.rst`); sphinx `-b doctest` 159/0. Lessons appended to `CONTEXT.md`.

brainmass now meets/exceeds tvboptim's observation set; EEG/MEG lead-field forwards remain a brainmass-only advantage.