### PR TITLE
fix(ci): repair version-verify step in Publish workflow

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -34,14 +34,14 @@ jobs:
           from pathlib import Path
           import re
           init = Path('brainmass/_version.py').read_text(encoding='utf-8')
-          m = re.search(r"__version__\s*=\s*['"]([^'"]+)['"]", init)
+          m = re.search(r'__version__\s*=\s*"([^"]+)"', init)
           print(m.group(1) if m else '')
           PY
           )
           echo "Release tag: $TAG"
           echo "Package version: $VERSION"
           if [ -z "$VERSION" ]; then
-            echo "Could not determine version from brainmass/__init__.py" >&2
+            echo "Could not determine version from brainmass/_version.py" >&2
             exit 1
           fi
           if [ "$TAG" != "$VERSION" ]; then


### PR DESCRIPTION
## Summary

The `Verify tag matches version` step in `Publish.yml` has **never run successfully**. Its regex line mixed `'` and `"` inside a `r"..."` raw string:

```python
m = re.search(r"__version__\s*=\s*['"]([^'"]+)['"]", init)
```

The raw string terminates at the first `"` inside the character class, producing a Python `SyntaxError` (`closing parenthesis ']' does not match opening parenthesis '('`). The step is guarded by `if: github.event_name == 'release'`, so it was skipped on every prior `workflow_dispatch` and only fired on the **v0.1.0** release — where it crashed the job *before* the build/publish steps (so 0.1.0 did not reach PyPI).

## Fix

- Use a single-quoted raw string matching the double-quoted `__version__` literal: `r'__version__\s*=\s*"([^"]+)"'`. Validated locally against `brainmass/_version.py` → parses `0.1.0`, and `TAG == VERSION` passes for tag `v0.1.0`.
- Correct the stale error-message path (`brainmass/__init__.py` → `brainmass/_version.py`).

This follows the earlier #61 fix (which corrected the file *path* in the same step but not this second, latent quoting bug). 0.1.0 will be published to PyPI via `workflow_dispatch` once this is on `main`.

## Summary by Sourcery

Fix the publish workflow’s version verification step so release tags can be validated against the package version without failing the job.

CI:
- Correct the regex used to extract __version__ from brainmass/_version.py in the Publish workflow so the version-verify step runs successfully.
- Update the error message in the Publish workflow to reference brainmass/_version.py instead of the outdated brainmass/__init__.py path.